### PR TITLE
Import firestore/v1 tests from googleapis/google-cloud-commons@f8189e138b7d6a368288b4e19605d261c281ea0e

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ generated
 
 # Go binary
 validator
+
+.idea

--- a/.kokoro/validator.sh
+++ b/.kokoro/validator.sh
@@ -40,7 +40,6 @@ function storage() {
 
 
 function firestore() {
-
   pushd ${TMP:-/tmp}
   rm -rf googleapis || true
   # Clone googleapis/googleapis to get the proto files needed by protoc
@@ -68,10 +67,8 @@ function firestore() {
 }
 
 function main() {
-
   storage
   firestore
-
 }
 
 main

--- a/firestore/v1/README.md
+++ b/firestore/v1/README.md
@@ -1,0 +1,9 @@
+# Cross-Language Tests for Google Firestore Clients
+
+A common set of test cases to verify behavior of Firestore Clients.
+
+- `proto`: the protobuffers defining the test format.
+
+- `testcase`: the tests.
+   - `*.json`: a single test in json serialized format, the schema of the json matches that of the 
+     proto definition in `proto`.

--- a/firestore/v1/proto/google/cloud/conformance/firestore/v1/tests.proto
+++ b/firestore/v1/proto/google/cloud/conformance/firestore/v1/tests.proto
@@ -1,0 +1,213 @@
+// Copyright 2019 Google LLC.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+// Tests for firestore clients.
+
+syntax = "proto3";
+
+package google.cloud.conformance.firestore.v1;
+
+option php_namespace = "Google\\Cloud\\Firestore\\Tests\\Conformance";
+option csharp_namespace = "Google.Cloud.Firestore.Tests.Proto";
+option java_outer_classname = "TestDefinition";
+option java_package = "com.google.cloud.conformance.firestore.v1";
+
+import "google/firestore/v1/common.proto";
+import "google/firestore/v1/document.proto";
+import "google/firestore/v1/firestore.proto";
+import "google/firestore/v1/query.proto";
+import "google/protobuf/timestamp.proto";
+
+// A collection of tests.
+message TestSuite {
+  repeated Test tests = 1;
+}
+
+// A Test describes a single client method call and its expected result.
+message Test {
+  string description = 1; // short description of the test
+  string comment = 10; // a comment describing the behavior being tested
+
+  oneof test {
+    GetTest         get = 2;
+    CreateTest      create = 3;
+    SetTest         set = 4;
+    UpdateTest      update = 5;
+    UpdatePathsTest update_paths = 6;
+    DeleteTest      delete = 7;
+    QueryTest       query = 8;
+    ListenTest      listen = 9;
+  }
+}
+
+// Call to the DocumentRef.Get method.
+message GetTest {
+  // The path of the doc, e.g. "projects/projectID/databases/(default)/documents/C/d"
+  string doc_ref_path = 1;
+
+  // The request that the call should send to the Firestore service.
+  google.firestore.v1.GetDocumentRequest request = 2;
+}
+
+// Call to DocumentRef.Create.
+message CreateTest {
+  // The path of the doc, e.g. "projects/projectID/databases/(default)/documents/C/d"
+  string doc_ref_path = 1;
+
+  // The data passed to Create, as JSON. The strings "Delete" and "ServerTimestamp"
+  // denote the two special sentinel values. Values that could be interpreted as integers
+  // (i.e. digit strings) should be treated as integers.
+  string json_data = 2;
+
+  // The request that the call should generate.
+  google.firestore.v1.CommitRequest request = 3;
+
+  // If true, the call should result in an error without generating a request.
+  // If this is true, request should not be set.
+  bool is_error = 4;
+}
+
+// A call to DocumentRef.Set.
+message SetTest {
+  string doc_ref_path = 1;         // path of doc
+  SetOption option = 2;            // option to the Set call, if any
+  string json_data = 3;            // data (see CreateTest.json_data)
+  google.firestore.v1.CommitRequest request = 4; // expected request
+  bool is_error = 5;               // call signals an error
+}
+
+// A call to the form of DocumentRef.Update that represents the data as a map
+// or dictionary.
+message UpdateTest {
+  string doc_ref_path = 1; // path of doc
+  google.firestore.v1.Precondition precondition = 2; // precondition in call, if any
+  string json_data  = 3;   // data (see CreateTest.json_data)
+  google.firestore.v1.CommitRequest request = 4; // expected request
+  bool is_error = 5;       // call signals an error
+}
+
+// A call to the form of DocumentRef.Update that represents the data as a list
+// of field paths and their values.
+message UpdatePathsTest {
+  string doc_ref_path = 1; // path of doc
+  google.firestore.v1.Precondition precondition = 2; // precondition in call, if any
+  // parallel sequences: field_paths[i] corresponds to json_values[i]
+  repeated FieldPath field_paths = 3; // the argument field paths
+  repeated string json_values = 4;    // the argument values, as JSON
+  google.firestore.v1.CommitRequest request = 5; // expected rquest
+  bool is_error = 6; // call signals an error
+}
+
+// A call to DocmentRef.Delete
+message DeleteTest {
+  string doc_ref_path = 1; // path of doc
+  google.firestore.v1.Precondition precondition = 2;
+  google.firestore.v1.CommitRequest request = 3; // expected rquest
+  bool is_error = 4;       // call signals an error
+}
+
+// An option to the DocumentRef.Set call.
+message SetOption {
+  bool all = 1;                  // if true, merge all fields ("fields" is ignored).
+  repeated FieldPath fields = 2; // field paths for a Merge option
+}
+
+message QueryTest {
+  string coll_path = 1; // path of collection, e.g. "projects/projectID/databases/(default)/documents/C"
+  repeated Clause clauses = 2;
+  google.firestore.v1.StructuredQuery query = 3;
+  bool is_error = 4;
+}
+
+message Clause {
+  oneof clause {
+    Select select = 1;
+    Where where = 2;
+    OrderBy order_by = 3;
+    int32 offset = 4;
+    int32 limit = 5;
+    Cursor start_at = 6;
+    Cursor start_after = 7;
+    Cursor end_at = 8;
+    Cursor end_before = 9;
+  }
+}
+
+message Select {
+  repeated FieldPath fields = 1;
+}
+
+message Where {
+  FieldPath path = 1;
+  string op = 2;
+  string json_value = 3;
+}
+
+message OrderBy {
+  FieldPath path = 1;
+  string direction = 2; // "asc" or "desc"
+}
+
+message Cursor {
+  // one of:
+  DocSnapshot doc_snapshot = 1;
+  repeated string json_values = 2;
+}
+
+message DocSnapshot {
+  string path = 1;
+  string json_data = 2;
+}
+
+message FieldPath {
+  repeated string field = 1;
+}
+
+// A test of the Listen streaming RPC (a.k.a. FireStore watch).
+// If the sequence of responses is provided to the implementation,
+// it should produce the sequence of snapshots.
+// If is_error is true, an error should occur after the snapshots.
+//
+// The tests assume that the query is
+// Collection("projects/projectID/databases/(default)/documents/C").OrderBy("a", Ascending)
+//
+// The watch target ID used in these tests is 1. Test interpreters
+// should either change their client's ID for testing,
+// or change the ID in the tests before running them.
+message ListenTest {
+  repeated google.firestore.v1.ListenResponse responses = 1;
+  repeated Snapshot snapshots = 2;
+  bool is_error = 3;
+}
+
+message Snapshot {
+  repeated google.firestore.v1.Document docs = 1;
+  repeated DocChange changes = 2;
+  google.protobuf.Timestamp read_time = 3;
+}
+
+message DocChange {
+  enum Kind {
+    KIND_UNSPECIFIED = 0;
+    ADDED = 1;
+    REMOVED = 2;
+    MODIFIED = 3;
+  }
+
+  Kind kind = 1;
+  google.firestore.v1.Document doc = 2;
+  int32 old_index = 3;
+  int32 new_index = 4;
+}

--- a/firestore/v1/testcase/create-all-transforms.json
+++ b/firestore/v1/testcase/create-all-transforms.json
@@ -1,0 +1,69 @@
+{
+  "description": "create: all transforms in a single call",
+  "comment": "A document can be created with any amount of transforms.",
+  "create": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\", \"c\": [\"ArrayUnion\", 1, 2, 3], \"d\": [\"ArrayRemove\", 4, 5, 6]}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "currentDocument": {
+            "exists": false
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b",
+                "setToServerValue": "REQUEST_TIME"
+              },
+              {
+                "fieldPath": "c",
+                "appendMissingElements": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "integerValue": "2"
+                    },
+                    {
+                      "integerValue": "3"
+                    }
+                  ]
+                }
+              },
+              {
+                "fieldPath": "d",
+                "removeAllFromArray": {
+                  "values": [
+                    {
+                      "integerValue": "4"
+                    },
+                    {
+                      "integerValue": "5"
+                    },
+                    {
+                      "integerValue": "6"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/create-all-transforms.json
+++ b/firestore/v1/testcase/create-all-transforms.json
@@ -1,69 +1,73 @@
 {
-  "description": "create: all transforms in a single call",
-  "comment": "A document can be created with any amount of transforms.",
-  "create": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\", \"c\": [\"ArrayUnion\", 1, 2, 3], \"d\": [\"ArrayRemove\", 4, 5, 6]}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
+  "tests": [
+    {
+      "description": "create: all transforms in a single call",
+      "comment": "A document can be created with any amount of transforms.",
+      "create": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\", \"c\": [\"ArrayUnion\", 1, 2, 3], \"d\": [\"ArrayRemove\", 4, 5, 6]}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              },
+              "currentDocument": {
+                "exists": false
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b",
+                    "setToServerValue": "REQUEST_TIME"
+                  },
+                  {
+                    "fieldPath": "c",
+                    "appendMissingElements": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "integerValue": "2"
+                        },
+                        {
+                          "integerValue": "3"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "fieldPath": "d",
+                    "removeAllFromArray": {
+                      "values": [
+                        {
+                          "integerValue": "4"
+                        },
+                        {
+                          "integerValue": "5"
+                        },
+                        {
+                          "integerValue": "6"
+                        }
+                      ]
+                    }
+                  }
+                ]
               }
             }
-          },
-          "currentDocument": {
-            "exists": false
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b",
-                "setToServerValue": "REQUEST_TIME"
-              },
-              {
-                "fieldPath": "c",
-                "appendMissingElements": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "integerValue": "2"
-                    },
-                    {
-                      "integerValue": "3"
-                    }
-                  ]
-                }
-              },
-              {
-                "fieldPath": "d",
-                "removeAllFromArray": {
-                  "values": [
-                    {
-                      "integerValue": "4"
-                    },
-                    {
-                      "integerValue": "5"
-                    },
-                    {
-                      "integerValue": "6"
-                    }
-                  ]
-                }
-              }
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/create-arrayremove-multi.json
+++ b/firestore/v1/testcase/create-arrayremove-multi.json
@@ -1,0 +1,65 @@
+{
+  "description": "create: multiple ArrayRemove fields",
+  "comment": "A document can have more than one ArrayRemove field.\nSince all the ArrayRemove fields are removed, the only field in the update is \"a\".",
+  "create": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b\": [\"ArrayRemove\", 1, 2, 3], \"c\": {\"d\": [\"ArrayRemove\", 4, 5, 6]}}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "currentDocument": {
+            "exists": false
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b",
+                "removeAllFromArray": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "integerValue": "2"
+                    },
+                    {
+                      "integerValue": "3"
+                    }
+                  ]
+                }
+              },
+              {
+                "fieldPath": "c.d",
+                "removeAllFromArray": {
+                  "values": [
+                    {
+                      "integerValue": "4"
+                    },
+                    {
+                      "integerValue": "5"
+                    },
+                    {
+                      "integerValue": "6"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/create-arrayremove-multi.json
+++ b/firestore/v1/testcase/create-arrayremove-multi.json
@@ -1,65 +1,69 @@
 {
-  "description": "create: multiple ArrayRemove fields",
-  "comment": "A document can have more than one ArrayRemove field.\nSince all the ArrayRemove fields are removed, the only field in the update is \"a\".",
-  "create": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b\": [\"ArrayRemove\", 1, 2, 3], \"c\": {\"d\": [\"ArrayRemove\", 4, 5, 6]}}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            }
-          },
-          "currentDocument": {
-            "exists": false
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b",
-                "removeAllFromArray": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "integerValue": "2"
-                    },
-                    {
-                      "integerValue": "3"
-                    }
-                  ]
+  "tests": [
+    {
+      "description": "create: multiple ArrayRemove fields",
+      "comment": "A document can have more than one ArrayRemove field.\nSince all the ArrayRemove fields are removed, the only field in the update is \"a\".",
+      "create": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b\": [\"ArrayRemove\", 1, 2, 3], \"c\": {\"d\": [\"ArrayRemove\", 4, 5, 6]}}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
                 }
               },
-              {
-                "fieldPath": "c.d",
-                "removeAllFromArray": {
-                  "values": [
-                    {
-                      "integerValue": "4"
-                    },
-                    {
-                      "integerValue": "5"
-                    },
-                    {
-                      "integerValue": "6"
-                    }
-                  ]
-                }
+              "currentDocument": {
+                "exists": false
               }
-            ]
-          }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b",
+                    "removeAllFromArray": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "integerValue": "2"
+                        },
+                        {
+                          "integerValue": "3"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "fieldPath": "c.d",
+                    "removeAllFromArray": {
+                      "values": [
+                        {
+                          "integerValue": "4"
+                        },
+                        {
+                          "integerValue": "5"
+                        },
+                        {
+                          "integerValue": "6"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/create-arrayremove-nested.json
+++ b/firestore/v1/testcase/create-arrayremove-nested.json
@@ -1,0 +1,49 @@
+{
+  "description": "create: nested ArrayRemove field",
+  "comment": "An ArrayRemove value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
+  "create": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b\": {\"c\": [\"ArrayRemove\", 1, 2, 3]}}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "currentDocument": {
+            "exists": false
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b.c",
+                "removeAllFromArray": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "integerValue": "2"
+                    },
+                    {
+                      "integerValue": "3"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/create-arrayremove-nested.json
+++ b/firestore/v1/testcase/create-arrayremove-nested.json
@@ -1,49 +1,53 @@
 {
-  "description": "create: nested ArrayRemove field",
-  "comment": "An ArrayRemove value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
-  "create": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b\": {\"c\": [\"ArrayRemove\", 1, 2, 3]}}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
+  "tests": [
+    {
+      "description": "create: nested ArrayRemove field",
+      "comment": "An ArrayRemove value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
+      "create": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b\": {\"c\": [\"ArrayRemove\", 1, 2, 3]}}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              },
+              "currentDocument": {
+                "exists": false
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b.c",
+                    "removeAllFromArray": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "integerValue": "2"
+                        },
+                        {
+                          "integerValue": "3"
+                        }
+                      ]
+                    }
+                  }
+                ]
               }
             }
-          },
-          "currentDocument": {
-            "exists": false
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b.c",
-                "removeAllFromArray": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "integerValue": "2"
-                    },
-                    {
-                      "integerValue": "3"
-                    }
-                  ]
-                }
-              }
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/create-arrayremove-noarray-nested.json
+++ b/firestore/v1/testcase/create-arrayremove-noarray-nested.json
@@ -1,0 +1,9 @@
+{
+  "description": "create: ArrayRemove cannot be anywhere inside an array value",
+  "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ArrayRemove. Firestore transforms don't support array indexing.",
+  "create": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [1, {\"b\": [\"ArrayRemove\", 1, 2, 3]}]}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/create-arrayremove-noarray-nested.json
+++ b/firestore/v1/testcase/create-arrayremove-noarray-nested.json
@@ -1,9 +1,13 @@
 {
-  "description": "create: ArrayRemove cannot be anywhere inside an array value",
-  "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ArrayRemove. Firestore transforms don't support array indexing.",
-  "create": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [1, {\"b\": [\"ArrayRemove\", 1, 2, 3]}]}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "create: ArrayRemove cannot be anywhere inside an array value",
+      "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ArrayRemove. Firestore transforms don't support array indexing.",
+      "create": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [1, {\"b\": [\"ArrayRemove\", 1, 2, 3]}]}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/create-arrayremove-noarray.json
+++ b/firestore/v1/testcase/create-arrayremove-noarray.json
@@ -1,0 +1,9 @@
+{
+  "description": "create: ArrayRemove cannot be in an array value",
+  "comment": "ArrayRemove must be the value of a field. Firestore\ntransforms don't support array indexing.",
+  "create": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [1, 2, [\"ArrayRemove\", 1, 2, 3]]}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/create-arrayremove-noarray.json
+++ b/firestore/v1/testcase/create-arrayremove-noarray.json
@@ -1,9 +1,13 @@
 {
-  "description": "create: ArrayRemove cannot be in an array value",
-  "comment": "ArrayRemove must be the value of a field. Firestore\ntransforms don't support array indexing.",
-  "create": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [1, 2, [\"ArrayRemove\", 1, 2, 3]]}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "create: ArrayRemove cannot be in an array value",
+      "comment": "ArrayRemove must be the value of a field. Firestore\ntransforms don't support array indexing.",
+      "create": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [1, 2, [\"ArrayRemove\", 1, 2, 3]]}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/create-arrayremove-with-st.json
+++ b/firestore/v1/testcase/create-arrayremove-with-st.json
@@ -1,0 +1,9 @@
+{
+  "description": "create: The ServerTimestamp sentinel cannot be in an ArrayUnion",
+  "comment": "The ServerTimestamp sentinel must be the value of a field. It may\nnot appear in an ArrayUnion.",
+  "create": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [\"ArrayRemove\", 1, \"ServerTimestamp\", 3]}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/create-arrayremove-with-st.json
+++ b/firestore/v1/testcase/create-arrayremove-with-st.json
@@ -1,9 +1,13 @@
 {
-  "description": "create: The ServerTimestamp sentinel cannot be in an ArrayUnion",
-  "comment": "The ServerTimestamp sentinel must be the value of a field. It may\nnot appear in an ArrayUnion.",
-  "create": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [\"ArrayRemove\", 1, \"ServerTimestamp\", 3]}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "create: The ServerTimestamp sentinel cannot be in an ArrayUnion",
+      "comment": "The ServerTimestamp sentinel must be the value of a field. It may\nnot appear in an ArrayUnion.",
+      "create": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [\"ArrayRemove\", 1, \"ServerTimestamp\", 3]}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/create-arrayremove.json
+++ b/firestore/v1/testcase/create-arrayremove.json
@@ -1,0 +1,49 @@
+{
+  "description": "create: ArrayRemove with data",
+  "comment": "A key with ArrayRemove is removed from the data in the update \noperation. Instead it appears in a separate Transform operation.",
+  "create": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b\": [\"ArrayRemove\", 1, 2, 3]}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "currentDocument": {
+            "exists": false
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b",
+                "removeAllFromArray": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "integerValue": "2"
+                    },
+                    {
+                      "integerValue": "3"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/create-arrayremove.json
+++ b/firestore/v1/testcase/create-arrayremove.json
@@ -1,49 +1,53 @@
 {
-  "description": "create: ArrayRemove with data",
-  "comment": "A key with ArrayRemove is removed from the data in the update \noperation. Instead it appears in a separate Transform operation.",
-  "create": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b\": [\"ArrayRemove\", 1, 2, 3]}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
+  "tests": [
+    {
+      "description": "create: ArrayRemove with data",
+      "comment": "A key with ArrayRemove is removed from the data in the update \noperation. Instead it appears in a separate Transform operation.",
+      "create": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b\": [\"ArrayRemove\", 1, 2, 3]}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              },
+              "currentDocument": {
+                "exists": false
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b",
+                    "removeAllFromArray": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "integerValue": "2"
+                        },
+                        {
+                          "integerValue": "3"
+                        }
+                      ]
+                    }
+                  }
+                ]
               }
             }
-          },
-          "currentDocument": {
-            "exists": false
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b",
-                "removeAllFromArray": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "integerValue": "2"
-                    },
-                    {
-                      "integerValue": "3"
-                    }
-                  ]
-                }
-              }
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/create-arrayunion-multi.json
+++ b/firestore/v1/testcase/create-arrayunion-multi.json
@@ -1,0 +1,65 @@
+{
+  "description": "create: multiple ArrayUnion fields",
+  "comment": "A document can have more than one ArrayUnion field.\nSince all the ArrayUnion fields are removed, the only field in the update is \"a\".",
+  "create": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b\": [\"ArrayUnion\", 1, 2, 3], \"c\": {\"d\": [\"ArrayUnion\", 4, 5, 6]}}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "currentDocument": {
+            "exists": false
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b",
+                "appendMissingElements": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "integerValue": "2"
+                    },
+                    {
+                      "integerValue": "3"
+                    }
+                  ]
+                }
+              },
+              {
+                "fieldPath": "c.d",
+                "appendMissingElements": {
+                  "values": [
+                    {
+                      "integerValue": "4"
+                    },
+                    {
+                      "integerValue": "5"
+                    },
+                    {
+                      "integerValue": "6"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/create-arrayunion-multi.json
+++ b/firestore/v1/testcase/create-arrayunion-multi.json
@@ -1,65 +1,69 @@
 {
-  "description": "create: multiple ArrayUnion fields",
-  "comment": "A document can have more than one ArrayUnion field.\nSince all the ArrayUnion fields are removed, the only field in the update is \"a\".",
-  "create": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b\": [\"ArrayUnion\", 1, 2, 3], \"c\": {\"d\": [\"ArrayUnion\", 4, 5, 6]}}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            }
-          },
-          "currentDocument": {
-            "exists": false
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b",
-                "appendMissingElements": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "integerValue": "2"
-                    },
-                    {
-                      "integerValue": "3"
-                    }
-                  ]
+  "tests": [
+    {
+      "description": "create: multiple ArrayUnion fields",
+      "comment": "A document can have more than one ArrayUnion field.\nSince all the ArrayUnion fields are removed, the only field in the update is \"a\".",
+      "create": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b\": [\"ArrayUnion\", 1, 2, 3], \"c\": {\"d\": [\"ArrayUnion\", 4, 5, 6]}}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
                 }
               },
-              {
-                "fieldPath": "c.d",
-                "appendMissingElements": {
-                  "values": [
-                    {
-                      "integerValue": "4"
-                    },
-                    {
-                      "integerValue": "5"
-                    },
-                    {
-                      "integerValue": "6"
-                    }
-                  ]
-                }
+              "currentDocument": {
+                "exists": false
               }
-            ]
-          }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b",
+                    "appendMissingElements": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "integerValue": "2"
+                        },
+                        {
+                          "integerValue": "3"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "fieldPath": "c.d",
+                    "appendMissingElements": {
+                      "values": [
+                        {
+                          "integerValue": "4"
+                        },
+                        {
+                          "integerValue": "5"
+                        },
+                        {
+                          "integerValue": "6"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/create-arrayunion-nested.json
+++ b/firestore/v1/testcase/create-arrayunion-nested.json
@@ -1,0 +1,49 @@
+{
+  "description": "create: nested ArrayUnion field",
+  "comment": "An ArrayUnion value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
+  "create": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b\": {\"c\": [\"ArrayUnion\", 1, 2, 3]}}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "currentDocument": {
+            "exists": false
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b.c",
+                "appendMissingElements": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "integerValue": "2"
+                    },
+                    {
+                      "integerValue": "3"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/create-arrayunion-nested.json
+++ b/firestore/v1/testcase/create-arrayunion-nested.json
@@ -1,49 +1,53 @@
 {
-  "description": "create: nested ArrayUnion field",
-  "comment": "An ArrayUnion value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
-  "create": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b\": {\"c\": [\"ArrayUnion\", 1, 2, 3]}}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
+  "tests": [
+    {
+      "description": "create: nested ArrayUnion field",
+      "comment": "An ArrayUnion value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
+      "create": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b\": {\"c\": [\"ArrayUnion\", 1, 2, 3]}}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              },
+              "currentDocument": {
+                "exists": false
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b.c",
+                    "appendMissingElements": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "integerValue": "2"
+                        },
+                        {
+                          "integerValue": "3"
+                        }
+                      ]
+                    }
+                  }
+                ]
               }
             }
-          },
-          "currentDocument": {
-            "exists": false
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b.c",
-                "appendMissingElements": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "integerValue": "2"
-                    },
-                    {
-                      "integerValue": "3"
-                    }
-                  ]
-                }
-              }
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/create-arrayunion-noarray-nested.json
+++ b/firestore/v1/testcase/create-arrayunion-noarray-nested.json
@@ -1,0 +1,9 @@
+{
+  "description": "create: ArrayUnion cannot be anywhere inside an array value",
+  "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ArrayUnion. Firestore transforms don't support array indexing.",
+  "create": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [1, {\"b\": [\"ArrayUnion\", 1, 2, 3]}]}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/create-arrayunion-noarray-nested.json
+++ b/firestore/v1/testcase/create-arrayunion-noarray-nested.json
@@ -1,9 +1,13 @@
 {
-  "description": "create: ArrayUnion cannot be anywhere inside an array value",
-  "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ArrayUnion. Firestore transforms don't support array indexing.",
-  "create": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [1, {\"b\": [\"ArrayUnion\", 1, 2, 3]}]}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "create: ArrayUnion cannot be anywhere inside an array value",
+      "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ArrayUnion. Firestore transforms don't support array indexing.",
+      "create": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [1, {\"b\": [\"ArrayUnion\", 1, 2, 3]}]}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/create-arrayunion-noarray.json
+++ b/firestore/v1/testcase/create-arrayunion-noarray.json
@@ -1,0 +1,9 @@
+{
+  "description": "create: ArrayUnion cannot be in an array value",
+  "comment": "ArrayUnion must be the value of a field. Firestore\ntransforms don't support array indexing.",
+  "create": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [1, 2, [\"ArrayRemove\", 1, 2, 3]]}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/create-arrayunion-noarray.json
+++ b/firestore/v1/testcase/create-arrayunion-noarray.json
@@ -1,9 +1,13 @@
 {
-  "description": "create: ArrayUnion cannot be in an array value",
-  "comment": "ArrayUnion must be the value of a field. Firestore\ntransforms don't support array indexing.",
-  "create": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [1, 2, [\"ArrayRemove\", 1, 2, 3]]}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "create: ArrayUnion cannot be in an array value",
+      "comment": "ArrayUnion must be the value of a field. Firestore\ntransforms don't support array indexing.",
+      "create": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [1, 2, [\"ArrayRemove\", 1, 2, 3]]}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/create-arrayunion-with-st.json
+++ b/firestore/v1/testcase/create-arrayunion-with-st.json
@@ -1,0 +1,9 @@
+{
+  "description": "create: The ServerTimestamp sentinel cannot be in an ArrayUnion",
+  "comment": "The ServerTimestamp sentinel must be the value of a field. It may\nnot appear in an ArrayUnion.",
+  "create": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [\"ArrayUnion\", 1, \"ServerTimestamp\", 3]}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/create-arrayunion-with-st.json
+++ b/firestore/v1/testcase/create-arrayunion-with-st.json
@@ -1,9 +1,13 @@
 {
-  "description": "create: The ServerTimestamp sentinel cannot be in an ArrayUnion",
-  "comment": "The ServerTimestamp sentinel must be the value of a field. It may\nnot appear in an ArrayUnion.",
-  "create": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [\"ArrayUnion\", 1, \"ServerTimestamp\", 3]}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "create: The ServerTimestamp sentinel cannot be in an ArrayUnion",
+      "comment": "The ServerTimestamp sentinel must be the value of a field. It may\nnot appear in an ArrayUnion.",
+      "create": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [\"ArrayUnion\", 1, \"ServerTimestamp\", 3]}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/create-arrayunion.json
+++ b/firestore/v1/testcase/create-arrayunion.json
@@ -1,0 +1,49 @@
+{
+  "description": "create: ArrayUnion with data",
+  "comment": "A key with ArrayUnion is removed from the data in the update \noperation. Instead it appears in a separate Transform operation.",
+  "create": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b\": [\"ArrayUnion\", 1, 2, 3]}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "currentDocument": {
+            "exists": false
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b",
+                "appendMissingElements": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "integerValue": "2"
+                    },
+                    {
+                      "integerValue": "3"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/create-arrayunion.json
+++ b/firestore/v1/testcase/create-arrayunion.json
@@ -1,49 +1,53 @@
 {
-  "description": "create: ArrayUnion with data",
-  "comment": "A key with ArrayUnion is removed from the data in the update \noperation. Instead it appears in a separate Transform operation.",
-  "create": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b\": [\"ArrayUnion\", 1, 2, 3]}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
+  "tests": [
+    {
+      "description": "create: ArrayUnion with data",
+      "comment": "A key with ArrayUnion is removed from the data in the update \noperation. Instead it appears in a separate Transform operation.",
+      "create": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b\": [\"ArrayUnion\", 1, 2, 3]}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              },
+              "currentDocument": {
+                "exists": false
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b",
+                    "appendMissingElements": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "integerValue": "2"
+                        },
+                        {
+                          "integerValue": "3"
+                        }
+                      ]
+                    }
+                  }
+                ]
               }
             }
-          },
-          "currentDocument": {
-            "exists": false
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b",
-                "appendMissingElements": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "integerValue": "2"
-                    },
-                    {
-                      "integerValue": "3"
-                    }
-                  ]
-                }
-              }
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/create-basic.json
+++ b/firestore/v1/testcase/create-basic.json
@@ -1,0 +1,26 @@
+{
+  "description": "create: basic",
+  "comment": "A simple call, resulting in a single update operation.",
+  "create": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "currentDocument": {
+            "exists": false
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/create-basic.json
+++ b/firestore/v1/testcase/create-basic.json
@@ -1,26 +1,30 @@
 {
-  "description": "create: basic",
-  "comment": "A simple call, resulting in a single update operation.",
-  "create": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
+  "tests": [
+    {
+      "description": "create: basic",
+      "comment": "A simple call, resulting in a single update operation.",
+      "create": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              },
+              "currentDocument": {
+                "exists": false
               }
             }
-          },
-          "currentDocument": {
-            "exists": false
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/create-complex.json
+++ b/firestore/v1/testcase/create-complex.json
@@ -1,0 +1,59 @@
+{
+  "description": "create: complex",
+  "comment": "A call to a write method with complicated input data.",
+  "create": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [1, 2.5], \"b\": {\"c\": [\"three\", {\"d\": true}]}}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "arrayValue": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "doubleValue": 2.5
+                    }
+                  ]
+                }
+              },
+              "b": {
+                "mapValue": {
+                  "fields": {
+                    "c": {
+                      "arrayValue": {
+                        "values": [
+                          {
+                            "stringValue": "three"
+                          },
+                          {
+                            "mapValue": {
+                              "fields": {
+                                "d": {
+                                  "booleanValue": true
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "currentDocument": {
+            "exists": false
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/create-complex.json
+++ b/firestore/v1/testcase/create-complex.json
@@ -1,59 +1,63 @@
 {
-  "description": "create: complex",
-  "comment": "A call to a write method with complicated input data.",
-  "create": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [1, 2.5], \"b\": {\"c\": [\"three\", {\"d\": true}]}}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "arrayValue": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "doubleValue": 2.5
+  "tests": [
+    {
+      "description": "create: complex",
+      "comment": "A call to a write method with complicated input data.",
+      "create": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [1, 2.5], \"b\": {\"c\": [\"three\", {\"d\": true}]}}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "arrayValue": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "doubleValue": 2.5
+                        }
+                      ]
                     }
-                  ]
-                }
-              },
-              "b": {
-                "mapValue": {
-                  "fields": {
-                    "c": {
-                      "arrayValue": {
-                        "values": [
-                          {
-                            "stringValue": "three"
-                          },
-                          {
-                            "mapValue": {
-                              "fields": {
-                                "d": {
-                                  "booleanValue": true
+                  },
+                  "b": {
+                    "mapValue": {
+                      "fields": {
+                        "c": {
+                          "arrayValue": {
+                            "values": [
+                              {
+                                "stringValue": "three"
+                              },
+                              {
+                                "mapValue": {
+                                  "fields": {
+                                    "d": {
+                                      "booleanValue": true
+                                    }
+                                  }
                                 }
                               }
-                            }
+                            ]
                           }
-                        ]
+                        }
                       }
                     }
                   }
                 }
+              },
+              "currentDocument": {
+                "exists": false
               }
             }
-          },
-          "currentDocument": {
-            "exists": false
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/create-del-noarray-nested.json
+++ b/firestore/v1/testcase/create-del-noarray-nested.json
@@ -1,0 +1,9 @@
+{
+  "description": "create: Delete cannot be anywhere inside an array value",
+  "comment": "The Delete sentinel must be the value of a field. Deletes are implemented\nby turning the path to the Delete sentinel into a FieldPath, and FieldPaths do not support\narray indexing.",
+  "create": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [1, {\"b\": \"Delete\"}]}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/create-del-noarray-nested.json
+++ b/firestore/v1/testcase/create-del-noarray-nested.json
@@ -1,9 +1,13 @@
 {
-  "description": "create: Delete cannot be anywhere inside an array value",
-  "comment": "The Delete sentinel must be the value of a field. Deletes are implemented\nby turning the path to the Delete sentinel into a FieldPath, and FieldPaths do not support\narray indexing.",
-  "create": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [1, {\"b\": \"Delete\"}]}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "create: Delete cannot be anywhere inside an array value",
+      "comment": "The Delete sentinel must be the value of a field. Deletes are implemented\nby turning the path to the Delete sentinel into a FieldPath, and FieldPaths do not support\narray indexing.",
+      "create": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [1, {\"b\": \"Delete\"}]}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/create-del-noarray.json
+++ b/firestore/v1/testcase/create-del-noarray.json
@@ -1,0 +1,9 @@
+{
+  "description": "create: Delete cannot be in an array value",
+  "comment": "The Delete sentinel must be the value of a field. Deletes are\nimplemented by turning the path to the Delete sentinel into a FieldPath, and FieldPaths\ndo not support array indexing.",
+  "create": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [1, 2, \"Delete\"]}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/create-del-noarray.json
+++ b/firestore/v1/testcase/create-del-noarray.json
@@ -1,9 +1,13 @@
 {
-  "description": "create: Delete cannot be in an array value",
-  "comment": "The Delete sentinel must be the value of a field. Deletes are\nimplemented by turning the path to the Delete sentinel into a FieldPath, and FieldPaths\ndo not support array indexing.",
-  "create": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [1, 2, \"Delete\"]}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "create: Delete cannot be in an array value",
+      "comment": "The Delete sentinel must be the value of a field. Deletes are\nimplemented by turning the path to the Delete sentinel into a FieldPath, and FieldPaths\ndo not support array indexing.",
+      "create": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [1, 2, \"Delete\"]}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/create-empty.json
+++ b/firestore/v1/testcase/create-empty.json
@@ -1,0 +1,21 @@
+{
+  "description": "create: creating or setting an empty map",
+  "create": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {}
+          },
+          "currentDocument": {
+            "exists": false
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/create-empty.json
+++ b/firestore/v1/testcase/create-empty.json
@@ -1,21 +1,25 @@
 {
-  "description": "create: creating or setting an empty map",
-  "create": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {}
-          },
-          "currentDocument": {
-            "exists": false
-          }
+  "tests": [
+    {
+      "description": "create: creating or setting an empty map",
+      "create": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {}
+              },
+              "currentDocument": {
+                "exists": false
+              }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/create-nodel.json
+++ b/firestore/v1/testcase/create-nodel.json
@@ -1,0 +1,9 @@
+{
+  "description": "create: Delete cannot appear in data",
+  "comment": "The Delete sentinel cannot be used in Create, or in Set without a Merge option.",
+  "create": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b\": \"Delete\"}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/create-nodel.json
+++ b/firestore/v1/testcase/create-nodel.json
@@ -1,9 +1,13 @@
 {
-  "description": "create: Delete cannot appear in data",
-  "comment": "The Delete sentinel cannot be used in Create, or in Set without a Merge option.",
-  "create": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b\": \"Delete\"}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "create: Delete cannot appear in data",
+      "comment": "The Delete sentinel cannot be used in Create, or in Set without a Merge option.",
+      "create": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b\": \"Delete\"}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/create-nosplit.json
+++ b/firestore/v1/testcase/create-nosplit.json
@@ -1,0 +1,35 @@
+{
+  "description": "create: don’t split on dots",
+  "comment": "Create and Set treat their map keys literally. They do not split on dots.",
+  "create": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{ \"a.b\": { \"c.d\": 1 }, \"e\": 2 }",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a.b": {
+                "mapValue": {
+                  "fields": {
+                    "c.d": {
+                      "integerValue": "1"
+                    }
+                  }
+                }
+              },
+              "e": {
+                "integerValue": "2"
+              }
+            }
+          },
+          "currentDocument": {
+            "exists": false
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/create-nosplit.json
+++ b/firestore/v1/testcase/create-nosplit.json
@@ -1,35 +1,39 @@
 {
-  "description": "create: don’t split on dots",
-  "comment": "Create and Set treat their map keys literally. They do not split on dots.",
-  "create": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{ \"a.b\": { \"c.d\": 1 }, \"e\": 2 }",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a.b": {
-                "mapValue": {
-                  "fields": {
-                    "c.d": {
-                      "integerValue": "1"
+  "tests": [
+    {
+      "description": "create: don’t split on dots",
+      "comment": "Create and Set treat their map keys literally. They do not split on dots.",
+      "create": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{ \"a.b\": { \"c.d\": 1 }, \"e\": 2 }",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a.b": {
+                    "mapValue": {
+                      "fields": {
+                        "c.d": {
+                          "integerValue": "1"
+                        }
+                      }
                     }
+                  },
+                  "e": {
+                    "integerValue": "2"
                   }
                 }
               },
-              "e": {
-                "integerValue": "2"
+              "currentDocument": {
+                "exists": false
               }
             }
-          },
-          "currentDocument": {
-            "exists": false
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/create-special-chars.json
+++ b/firestore/v1/testcase/create-special-chars.json
@@ -1,0 +1,35 @@
+{
+  "description": "create: non-alpha characters in map keys",
+  "comment": "Create and Set treat their map keys literally. They do not escape special characters.",
+  "create": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{ \"*\": { \".\": 1 }, \"~\": 2 }",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "*": {
+                "mapValue": {
+                  "fields": {
+                    ".": {
+                      "integerValue": "1"
+                    }
+                  }
+                }
+              },
+              "~": {
+                "integerValue": "2"
+              }
+            }
+          },
+          "currentDocument": {
+            "exists": false
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/create-special-chars.json
+++ b/firestore/v1/testcase/create-special-chars.json
@@ -1,35 +1,39 @@
 {
-  "description": "create: non-alpha characters in map keys",
-  "comment": "Create and Set treat their map keys literally. They do not escape special characters.",
-  "create": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{ \"*\": { \".\": 1 }, \"~\": 2 }",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "*": {
-                "mapValue": {
-                  "fields": {
-                    ".": {
-                      "integerValue": "1"
+  "tests": [
+    {
+      "description": "create: non-alpha characters in map keys",
+      "comment": "Create and Set treat their map keys literally. They do not escape special characters.",
+      "create": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{ \"*\": { \".\": 1 }, \"~\": 2 }",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "*": {
+                    "mapValue": {
+                      "fields": {
+                        ".": {
+                          "integerValue": "1"
+                        }
+                      }
                     }
+                  },
+                  "~": {
+                    "integerValue": "2"
                   }
                 }
               },
-              "~": {
-                "integerValue": "2"
+              "currentDocument": {
+                "exists": false
               }
             }
-          },
-          "currentDocument": {
-            "exists": false
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/create-st-alone.json
+++ b/firestore/v1/testcase/create-st-alone.json
@@ -1,0 +1,27 @@
+{
+  "description": "create: ServerTimestamp alone",
+  "comment": "If the only values in the input are ServerTimestamps, then no\nupdate operation should be produced.",
+  "create": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": \"ServerTimestamp\"}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "a",
+                "setToServerValue": "REQUEST_TIME"
+              }
+            ]
+          },
+          "currentDocument": {
+            "exists": false
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/create-st-alone.json
+++ b/firestore/v1/testcase/create-st-alone.json
@@ -1,27 +1,31 @@
 {
-  "description": "create: ServerTimestamp alone",
-  "comment": "If the only values in the input are ServerTimestamps, then no\nupdate operation should be produced.",
-  "create": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": \"ServerTimestamp\"}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "a",
-                "setToServerValue": "REQUEST_TIME"
+  "tests": [
+    {
+      "description": "create: ServerTimestamp alone",
+      "comment": "If the only values in the input are ServerTimestamps, then no\nupdate operation should be produced.",
+      "create": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": \"ServerTimestamp\"}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "a",
+                    "setToServerValue": "REQUEST_TIME"
+                  }
+                ]
+              },
+              "currentDocument": {
+                "exists": false
               }
-            ]
-          },
-          "currentDocument": {
-            "exists": false
-          }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/create-st-multi.json
+++ b/firestore/v1/testcase/create-st-multi.json
@@ -1,0 +1,41 @@
+{
+  "description": "create: multiple ServerTimestamp fields",
+  "comment": "A document can have more than one ServerTimestamp field.\nSince all the ServerTimestamp fields are removed, the only field in the update is \"a\".",
+  "create": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\", \"c\": {\"d\": \"ServerTimestamp\"}}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "currentDocument": {
+            "exists": false
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b",
+                "setToServerValue": "REQUEST_TIME"
+              },
+              {
+                "fieldPath": "c.d",
+                "setToServerValue": "REQUEST_TIME"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/create-st-multi.json
+++ b/firestore/v1/testcase/create-st-multi.json
@@ -1,41 +1,45 @@
 {
-  "description": "create: multiple ServerTimestamp fields",
-  "comment": "A document can have more than one ServerTimestamp field.\nSince all the ServerTimestamp fields are removed, the only field in the update is \"a\".",
-  "create": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\", \"c\": {\"d\": \"ServerTimestamp\"}}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
+  "tests": [
+    {
+      "description": "create: multiple ServerTimestamp fields",
+      "comment": "A document can have more than one ServerTimestamp field.\nSince all the ServerTimestamp fields are removed, the only field in the update is \"a\".",
+      "create": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\", \"c\": {\"d\": \"ServerTimestamp\"}}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              },
+              "currentDocument": {
+                "exists": false
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b",
+                    "setToServerValue": "REQUEST_TIME"
+                  },
+                  {
+                    "fieldPath": "c.d",
+                    "setToServerValue": "REQUEST_TIME"
+                  }
+                ]
               }
             }
-          },
-          "currentDocument": {
-            "exists": false
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b",
-                "setToServerValue": "REQUEST_TIME"
-              },
-              {
-                "fieldPath": "c.d",
-                "setToServerValue": "REQUEST_TIME"
-              }
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/create-st-nested.json
+++ b/firestore/v1/testcase/create-st-nested.json
@@ -1,0 +1,37 @@
+{
+  "description": "create: nested ServerTimestamp field",
+  "comment": "A ServerTimestamp value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
+  "create": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b\": {\"c\": \"ServerTimestamp\"}}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "currentDocument": {
+            "exists": false
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b.c",
+                "setToServerValue": "REQUEST_TIME"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/create-st-nested.json
+++ b/firestore/v1/testcase/create-st-nested.json
@@ -1,37 +1,41 @@
 {
-  "description": "create: nested ServerTimestamp field",
-  "comment": "A ServerTimestamp value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
-  "create": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b\": {\"c\": \"ServerTimestamp\"}}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
+  "tests": [
+    {
+      "description": "create: nested ServerTimestamp field",
+      "comment": "A ServerTimestamp value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
+      "create": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b\": {\"c\": \"ServerTimestamp\"}}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              },
+              "currentDocument": {
+                "exists": false
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b.c",
+                    "setToServerValue": "REQUEST_TIME"
+                  }
+                ]
               }
             }
-          },
-          "currentDocument": {
-            "exists": false
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b.c",
-                "setToServerValue": "REQUEST_TIME"
-              }
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/create-st-noarray-nested.json
+++ b/firestore/v1/testcase/create-st-noarray-nested.json
@@ -1,0 +1,9 @@
+{
+  "description": "create: ServerTimestamp cannot be anywhere inside an array value",
+  "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ServerTimestamp sentinel. Firestore transforms don't support array indexing.",
+  "create": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [1, {\"b\": \"ServerTimestamp\"}]}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/create-st-noarray-nested.json
+++ b/firestore/v1/testcase/create-st-noarray-nested.json
@@ -1,9 +1,13 @@
 {
-  "description": "create: ServerTimestamp cannot be anywhere inside an array value",
-  "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ServerTimestamp sentinel. Firestore transforms don't support array indexing.",
-  "create": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [1, {\"b\": \"ServerTimestamp\"}]}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "create: ServerTimestamp cannot be anywhere inside an array value",
+      "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ServerTimestamp sentinel. Firestore transforms don't support array indexing.",
+      "create": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [1, {\"b\": \"ServerTimestamp\"}]}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/create-st-noarray.json
+++ b/firestore/v1/testcase/create-st-noarray.json
@@ -1,0 +1,9 @@
+{
+  "description": "create: ServerTimestamp cannot be in an array value",
+  "comment": "The ServerTimestamp sentinel must be the value of a field. Firestore\ntransforms don't support array indexing.",
+  "create": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [1, 2, \"ServerTimestamp\"]}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/create-st-noarray.json
+++ b/firestore/v1/testcase/create-st-noarray.json
@@ -1,9 +1,13 @@
 {
-  "description": "create: ServerTimestamp cannot be in an array value",
-  "comment": "The ServerTimestamp sentinel must be the value of a field. Firestore\ntransforms don't support array indexing.",
-  "create": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [1, 2, \"ServerTimestamp\"]}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "create: ServerTimestamp cannot be in an array value",
+      "comment": "The ServerTimestamp sentinel must be the value of a field. Firestore\ntransforms don't support array indexing.",
+      "create": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [1, 2, \"ServerTimestamp\"]}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/create-st-with-empty-map.json
+++ b/firestore/v1/testcase/create-st-with-empty-map.json
@@ -1,0 +1,45 @@
+{
+  "description": "create: ServerTimestamp beside an empty map",
+  "comment": "When a ServerTimestamp and a map both reside inside a map, the\nServerTimestamp should be stripped out but the empty map should remain.",
+  "create": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": {\"b\": {}, \"c\": \"ServerTimestamp\"}}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "mapValue": {
+                  "fields": {
+                    "b": {
+                      "mapValue": {
+                        "fields": {}
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "currentDocument": {
+            "exists": false
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "a.c",
+                "setToServerValue": "REQUEST_TIME"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/create-st-with-empty-map.json
+++ b/firestore/v1/testcase/create-st-with-empty-map.json
@@ -1,45 +1,49 @@
 {
-  "description": "create: ServerTimestamp beside an empty map",
-  "comment": "When a ServerTimestamp and a map both reside inside a map, the\nServerTimestamp should be stripped out but the empty map should remain.",
-  "create": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": {\"b\": {}, \"c\": \"ServerTimestamp\"}}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "mapValue": {
-                  "fields": {
-                    "b": {
-                      "mapValue": {
-                        "fields": {}
+  "tests": [
+    {
+      "description": "create: ServerTimestamp beside an empty map",
+      "comment": "When a ServerTimestamp and a map both reside inside a map, the\nServerTimestamp should be stripped out but the empty map should remain.",
+      "create": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": {\"b\": {}, \"c\": \"ServerTimestamp\"}}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "mapValue": {
+                      "fields": {
+                        "b": {
+                          "mapValue": {
+                            "fields": {}
+                          }
+                        }
                       }
                     }
                   }
                 }
+              },
+              "currentDocument": {
+                "exists": false
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "a.c",
+                    "setToServerValue": "REQUEST_TIME"
+                  }
+                ]
               }
             }
-          },
-          "currentDocument": {
-            "exists": false
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "a.c",
-                "setToServerValue": "REQUEST_TIME"
-              }
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/create-st.json
+++ b/firestore/v1/testcase/create-st.json
@@ -1,0 +1,37 @@
+{
+  "description": "create: ServerTimestamp with data",
+  "comment": "A key with the special ServerTimestamp sentinel is removed from\nthe data in the update operation. Instead it appears in a separate Transform operation.\nNote that in these tests, the string \"ServerTimestamp\" should be replaced with the\nspecial ServerTimestamp value.",
+  "create": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\"}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "currentDocument": {
+            "exists": false
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b",
+                "setToServerValue": "REQUEST_TIME"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/create-st.json
+++ b/firestore/v1/testcase/create-st.json
@@ -1,37 +1,41 @@
 {
-  "description": "create: ServerTimestamp with data",
-  "comment": "A key with the special ServerTimestamp sentinel is removed from\nthe data in the update operation. Instead it appears in a separate Transform operation.\nNote that in these tests, the string \"ServerTimestamp\" should be replaced with the\nspecial ServerTimestamp value.",
-  "create": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\"}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
+  "tests": [
+    {
+      "description": "create: ServerTimestamp with data",
+      "comment": "A key with the special ServerTimestamp sentinel is removed from\nthe data in the update operation. Instead it appears in a separate Transform operation.\nNote that in these tests, the string \"ServerTimestamp\" should be replaced with the\nspecial ServerTimestamp value.",
+      "create": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\"}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              },
+              "currentDocument": {
+                "exists": false
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b",
+                    "setToServerValue": "REQUEST_TIME"
+                  }
+                ]
               }
             }
-          },
-          "currentDocument": {
-            "exists": false
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b",
-                "setToServerValue": "REQUEST_TIME"
-              }
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/delete-exists-precond.json
+++ b/firestore/v1/testcase/delete-exists-precond.json
@@ -1,0 +1,21 @@
+{
+  "description": "delete: delete with exists precondition",
+  "comment": "Delete supports an exists precondition.",
+  "delete": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "precondition": {
+      "exists": true
+    },
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "delete": "projects/projectID/databases/(default)/documents/C/d",
+          "currentDocument": {
+            "exists": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/delete-exists-precond.json
+++ b/firestore/v1/testcase/delete-exists-precond.json
@@ -1,21 +1,25 @@
 {
-  "description": "delete: delete with exists precondition",
-  "comment": "Delete supports an exists precondition.",
-  "delete": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "precondition": {
-      "exists": true
-    },
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "delete": "projects/projectID/databases/(default)/documents/C/d",
-          "currentDocument": {
-            "exists": true
-          }
+  "tests": [
+    {
+      "description": "delete: delete with exists precondition",
+      "comment": "Delete supports an exists precondition.",
+      "delete": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "precondition": {
+          "exists": true
+        },
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "delete": "projects/projectID/databases/(default)/documents/C/d",
+              "currentDocument": {
+                "exists": true
+              }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/delete-no-precond.json
+++ b/firestore/v1/testcase/delete-no-precond.json
@@ -1,0 +1,15 @@
+{
+  "description": "delete: delete without precondition",
+  "comment": "An ordinary Delete call.",
+  "delete": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "delete": "projects/projectID/databases/(default)/documents/C/d"
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/delete-no-precond.json
+++ b/firestore/v1/testcase/delete-no-precond.json
@@ -1,15 +1,19 @@
 {
-  "description": "delete: delete without precondition",
-  "comment": "An ordinary Delete call.",
-  "delete": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "delete": "projects/projectID/databases/(default)/documents/C/d"
+  "tests": [
+    {
+      "description": "delete: delete without precondition",
+      "comment": "An ordinary Delete call.",
+      "delete": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "delete": "projects/projectID/databases/(default)/documents/C/d"
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/delete-time-precond.json
+++ b/firestore/v1/testcase/delete-time-precond.json
@@ -1,0 +1,21 @@
+{
+  "description": "delete: delete with last-update-time precondition",
+  "comment": "Delete supports a last-update-time precondition.",
+  "delete": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "precondition": {
+      "updateTime": "1970-01-01T00:00:42Z"
+    },
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "delete": "projects/projectID/databases/(default)/documents/C/d",
+          "currentDocument": {
+            "updateTime": "1970-01-01T00:00:42Z"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/delete-time-precond.json
+++ b/firestore/v1/testcase/delete-time-precond.json
@@ -1,21 +1,25 @@
 {
-  "description": "delete: delete with last-update-time precondition",
-  "comment": "Delete supports a last-update-time precondition.",
-  "delete": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "precondition": {
-      "updateTime": "1970-01-01T00:00:42Z"
-    },
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "delete": "projects/projectID/databases/(default)/documents/C/d",
-          "currentDocument": {
-            "updateTime": "1970-01-01T00:00:42Z"
-          }
+  "tests": [
+    {
+      "description": "delete: delete with last-update-time precondition",
+      "comment": "Delete supports a last-update-time precondition.",
+      "delete": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "precondition": {
+          "updateTime": "1970-01-01T00:00:42Z"
+        },
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "delete": "projects/projectID/databases/(default)/documents/C/d",
+              "currentDocument": {
+                "updateTime": "1970-01-01T00:00:42Z"
+              }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/get-basic.json
+++ b/firestore/v1/testcase/get-basic.json
@@ -1,0 +1,10 @@
+{
+  "description": "get: get a document",
+  "comment": "A call to DocumentRef.Get",
+  "get": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "request": {
+      "name": "projects/projectID/databases/(default)/documents/C/d"
+    }
+  }
+}

--- a/firestore/v1/testcase/get-basic.json
+++ b/firestore/v1/testcase/get-basic.json
@@ -1,10 +1,14 @@
 {
-  "description": "get: get a document",
-  "comment": "A call to DocumentRef.Get",
-  "get": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "request": {
-      "name": "projects/projectID/databases/(default)/documents/C/d"
+  "tests": [
+    {
+      "description": "get: get a document",
+      "comment": "A call to DocumentRef.Get",
+      "get": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "request": {
+          "name": "projects/projectID/databases/(default)/documents/C/d"
+        }
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/listen-add-mod-del-add.json
+++ b/firestore/v1/testcase/listen-add-mod-del-add.json
@@ -1,0 +1,202 @@
+{
+  "description": "listen: add a doc, modify it, delete it, then add it again",
+  "comment": "Various changes to a single document.",
+  "listen": {
+    "responses": [
+      {
+        "documentChange": {
+          "document": {
+            "name": "projects/projectID/databases/(default)/documents/C/d1",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          },
+          "targetIds": [
+            1
+          ]
+        }
+      },
+      {
+        "targetChange": {
+          "targetChangeType": "CURRENT"
+        }
+      },
+      {
+        "targetChange": {
+          "readTime": "1970-01-01T00:00:01Z"
+        }
+      },
+      {
+        "documentChange": {
+          "document": {
+            "name": "projects/projectID/databases/(default)/documents/C/d1",
+            "fields": {
+              "a": {
+                "integerValue": "2"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:02Z"
+          },
+          "targetIds": [
+            1
+          ]
+        }
+      },
+      {
+        "targetChange": {
+          "readTime": "1970-01-01T00:00:02Z"
+        }
+      },
+      {
+        "documentDelete": {
+          "document": "projects/projectID/databases/(default)/documents/C/d1"
+        }
+      },
+      {
+        "targetChange": {
+          "readTime": "1970-01-01T00:00:03Z"
+        }
+      },
+      {
+        "documentChange": {
+          "document": {
+            "name": "projects/projectID/databases/(default)/documents/C/d1",
+            "fields": {
+              "a": {
+                "integerValue": "3"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:03Z"
+          },
+          "targetIds": [
+            1
+          ]
+        }
+      },
+      {
+        "targetChange": {
+          "readTime": "1970-01-01T00:00:04Z"
+        }
+      }
+    ],
+    "snapshots": [
+      {
+        "docs": [
+          {
+            "name": "projects/projectID/databases/(default)/documents/C/d1",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          }
+        ],
+        "changes": [
+          {
+            "kind": "ADDED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d1",
+              "fields": {
+                "a": {
+                  "integerValue": "1"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:01Z"
+            },
+            "oldIndex": -1
+          }
+        ],
+        "readTime": "1970-01-01T00:00:01Z"
+      },
+      {
+        "docs": [
+          {
+            "name": "projects/projectID/databases/(default)/documents/C/d1",
+            "fields": {
+              "a": {
+                "integerValue": "2"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:02Z"
+          }
+        ],
+        "changes": [
+          {
+            "kind": "MODIFIED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d1",
+              "fields": {
+                "a": {
+                  "integerValue": "2"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:02Z"
+            }
+          }
+        ],
+        "readTime": "1970-01-01T00:00:02Z"
+      },
+      {
+        "changes": [
+          {
+            "kind": "REMOVED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d1",
+              "fields": {
+                "a": {
+                  "integerValue": "2"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:02Z"
+            },
+            "newIndex": -1
+          }
+        ],
+        "readTime": "1970-01-01T00:00:03Z"
+      },
+      {
+        "docs": [
+          {
+            "name": "projects/projectID/databases/(default)/documents/C/d1",
+            "fields": {
+              "a": {
+                "integerValue": "3"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:03Z"
+          }
+        ],
+        "changes": [
+          {
+            "kind": "ADDED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d1",
+              "fields": {
+                "a": {
+                  "integerValue": "3"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:03Z"
+            },
+            "oldIndex": -1
+          }
+        ],
+        "readTime": "1970-01-01T00:00:04Z"
+      }
+    ]
+  }
+}

--- a/firestore/v1/testcase/listen-add-mod-del-add.json
+++ b/firestore/v1/testcase/listen-add-mod-del-add.json
@@ -1,202 +1,206 @@
 {
-  "description": "listen: add a doc, modify it, delete it, then add it again",
-  "comment": "Various changes to a single document.",
-  "listen": {
-    "responses": [
-      {
-        "documentChange": {
-          "document": {
-            "name": "projects/projectID/databases/(default)/documents/C/d1",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          },
-          "targetIds": [
-            1
-          ]
-        }
-      },
-      {
-        "targetChange": {
-          "targetChangeType": "CURRENT"
-        }
-      },
-      {
-        "targetChange": {
-          "readTime": "1970-01-01T00:00:01Z"
-        }
-      },
-      {
-        "documentChange": {
-          "document": {
-            "name": "projects/projectID/databases/(default)/documents/C/d1",
-            "fields": {
-              "a": {
-                "integerValue": "2"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:02Z"
-          },
-          "targetIds": [
-            1
-          ]
-        }
-      },
-      {
-        "targetChange": {
-          "readTime": "1970-01-01T00:00:02Z"
-        }
-      },
-      {
-        "documentDelete": {
-          "document": "projects/projectID/databases/(default)/documents/C/d1"
-        }
-      },
-      {
-        "targetChange": {
-          "readTime": "1970-01-01T00:00:03Z"
-        }
-      },
-      {
-        "documentChange": {
-          "document": {
-            "name": "projects/projectID/databases/(default)/documents/C/d1",
-            "fields": {
-              "a": {
-                "integerValue": "3"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:03Z"
-          },
-          "targetIds": [
-            1
-          ]
-        }
-      },
-      {
-        "targetChange": {
-          "readTime": "1970-01-01T00:00:04Z"
-        }
-      }
-    ],
-    "snapshots": [
-      {
-        "docs": [
+  "tests": [
+    {
+      "description": "listen: add a doc, modify it, delete it, then add it again",
+      "comment": "Various changes to a single document.",
+      "listen": {
+        "responses": [
           {
-            "name": "projects/projectID/databases/(default)/documents/C/d1",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          }
-        ],
-        "changes": [
-          {
-            "kind": "ADDED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d1",
-              "fields": {
-                "a": {
-                  "integerValue": "1"
-                }
+            "documentChange": {
+              "document": {
+                "name": "projects/projectID/databases/(default)/documents/C/d1",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
               },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:01Z"
-            },
-            "oldIndex": -1
-          }
-        ],
-        "readTime": "1970-01-01T00:00:01Z"
-      },
-      {
-        "docs": [
+              "targetIds": [
+                1
+              ]
+            }
+          },
           {
-            "name": "projects/projectID/databases/(default)/documents/C/d1",
-            "fields": {
-              "a": {
-                "integerValue": "2"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:02Z"
-          }
-        ],
-        "changes": [
+            "targetChange": {
+              "targetChangeType": "CURRENT"
+            }
+          },
           {
-            "kind": "MODIFIED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d1",
-              "fields": {
-                "a": {
-                  "integerValue": "2"
-                }
+            "targetChange": {
+              "readTime": "1970-01-01T00:00:01Z"
+            }
+          },
+          {
+            "documentChange": {
+              "document": {
+                "name": "projects/projectID/databases/(default)/documents/C/d1",
+                "fields": {
+                  "a": {
+                    "integerValue": "2"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:02Z"
               },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:02Z"
+              "targetIds": [
+                1
+              ]
+            }
+          },
+          {
+            "targetChange": {
+              "readTime": "1970-01-01T00:00:02Z"
+            }
+          },
+          {
+            "documentDelete": {
+              "document": "projects/projectID/databases/(default)/documents/C/d1"
+            }
+          },
+          {
+            "targetChange": {
+              "readTime": "1970-01-01T00:00:03Z"
+            }
+          },
+          {
+            "documentChange": {
+              "document": {
+                "name": "projects/projectID/databases/(default)/documents/C/d1",
+                "fields": {
+                  "a": {
+                    "integerValue": "3"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:03Z"
+              },
+              "targetIds": [
+                1
+              ]
+            }
+          },
+          {
+            "targetChange": {
+              "readTime": "1970-01-01T00:00:04Z"
             }
           }
         ],
-        "readTime": "1970-01-01T00:00:02Z"
-      },
-      {
-        "changes": [
+        "snapshots": [
           {
-            "kind": "REMOVED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d1",
-              "fields": {
-                "a": {
-                  "integerValue": "2"
-                }
-              },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:02Z"
-            },
-            "newIndex": -1
-          }
-        ],
-        "readTime": "1970-01-01T00:00:03Z"
-      },
-      {
-        "docs": [
-          {
-            "name": "projects/projectID/databases/(default)/documents/C/d1",
-            "fields": {
-              "a": {
-                "integerValue": "3"
+            "docs": [
+              {
+                "name": "projects/projectID/databases/(default)/documents/C/d1",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
               }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:03Z"
-          }
-        ],
-        "changes": [
+            ],
+            "changes": [
+              {
+                "kind": "ADDED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d1",
+                  "fields": {
+                    "a": {
+                      "integerValue": "1"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:01Z"
+                },
+                "oldIndex": -1
+              }
+            ],
+            "readTime": "1970-01-01T00:00:01Z"
+          },
           {
-            "kind": "ADDED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d1",
-              "fields": {
-                "a": {
-                  "integerValue": "3"
+            "docs": [
+              {
+                "name": "projects/projectID/databases/(default)/documents/C/d1",
+                "fields": {
+                  "a": {
+                    "integerValue": "2"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:02Z"
+              }
+            ],
+            "changes": [
+              {
+                "kind": "MODIFIED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d1",
+                  "fields": {
+                    "a": {
+                      "integerValue": "2"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:02Z"
                 }
-              },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:03Z"
-            },
-            "oldIndex": -1
+              }
+            ],
+            "readTime": "1970-01-01T00:00:02Z"
+          },
+          {
+            "changes": [
+              {
+                "kind": "REMOVED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d1",
+                  "fields": {
+                    "a": {
+                      "integerValue": "2"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:02Z"
+                },
+                "newIndex": -1
+              }
+            ],
+            "readTime": "1970-01-01T00:00:03Z"
+          },
+          {
+            "docs": [
+              {
+                "name": "projects/projectID/databases/(default)/documents/C/d1",
+                "fields": {
+                  "a": {
+                    "integerValue": "3"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:03Z"
+              }
+            ],
+            "changes": [
+              {
+                "kind": "ADDED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d1",
+                  "fields": {
+                    "a": {
+                      "integerValue": "3"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:03Z"
+                },
+                "oldIndex": -1
+              }
+            ],
+            "readTime": "1970-01-01T00:00:04Z"
           }
-        ],
-        "readTime": "1970-01-01T00:00:04Z"
+        ]
       }
-    ]
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/listen-add-one.json
+++ b/firestore/v1/testcase/listen-add-one.json
@@ -1,0 +1,68 @@
+{
+  "description": "listen: add a doc",
+  "comment": "Snapshot with a single document.",
+  "listen": {
+    "responses": [
+      {
+        "documentChange": {
+          "document": {
+            "name": "projects/projectID/databases/(default)/documents/C/d1",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          },
+          "targetIds": [
+            1
+          ]
+        }
+      },
+      {
+        "targetChange": {
+          "targetChangeType": "CURRENT"
+        }
+      },
+      {
+        "targetChange": {
+          "readTime": "1970-01-01T00:00:02Z"
+        }
+      }
+    ],
+    "snapshots": [
+      {
+        "docs": [
+          {
+            "name": "projects/projectID/databases/(default)/documents/C/d1",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          }
+        ],
+        "changes": [
+          {
+            "kind": "ADDED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d1",
+              "fields": {
+                "a": {
+                  "integerValue": "1"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:01Z"
+            },
+            "oldIndex": -1
+          }
+        ],
+        "readTime": "1970-01-01T00:00:02Z"
+      }
+    ]
+  }
+}

--- a/firestore/v1/testcase/listen-add-one.json
+++ b/firestore/v1/testcase/listen-add-one.json
@@ -1,68 +1,72 @@
 {
-  "description": "listen: add a doc",
-  "comment": "Snapshot with a single document.",
-  "listen": {
-    "responses": [
-      {
-        "documentChange": {
-          "document": {
-            "name": "projects/projectID/databases/(default)/documents/C/d1",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          },
-          "targetIds": [
-            1
-          ]
-        }
-      },
-      {
-        "targetChange": {
-          "targetChangeType": "CURRENT"
-        }
-      },
-      {
-        "targetChange": {
-          "readTime": "1970-01-01T00:00:02Z"
-        }
-      }
-    ],
-    "snapshots": [
-      {
-        "docs": [
+  "tests": [
+    {
+      "description": "listen: add a doc",
+      "comment": "Snapshot with a single document.",
+      "listen": {
+        "responses": [
           {
-            "name": "projects/projectID/databases/(default)/documents/C/d1",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          }
-        ],
-        "changes": [
-          {
-            "kind": "ADDED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d1",
-              "fields": {
-                "a": {
-                  "integerValue": "1"
-                }
+            "documentChange": {
+              "document": {
+                "name": "projects/projectID/databases/(default)/documents/C/d1",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
               },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:01Z"
-            },
-            "oldIndex": -1
+              "targetIds": [
+                1
+              ]
+            }
+          },
+          {
+            "targetChange": {
+              "targetChangeType": "CURRENT"
+            }
+          },
+          {
+            "targetChange": {
+              "readTime": "1970-01-01T00:00:02Z"
+            }
           }
         ],
-        "readTime": "1970-01-01T00:00:02Z"
+        "snapshots": [
+          {
+            "docs": [
+              {
+                "name": "projects/projectID/databases/(default)/documents/C/d1",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
+              }
+            ],
+            "changes": [
+              {
+                "kind": "ADDED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d1",
+                  "fields": {
+                    "a": {
+                      "integerValue": "1"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:01Z"
+                },
+                "oldIndex": -1
+              }
+            ],
+            "readTime": "1970-01-01T00:00:02Z"
+          }
+        ]
       }
-    ]
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/listen-add-three.json
+++ b/firestore/v1/testcase/listen-add-three.json
@@ -1,0 +1,152 @@
+{
+  "description": "listen: add three documents",
+  "comment": "A snapshot with three documents. The documents are sorted\nfirst by the \"a\" field, then by their path. The changes are ordered the same way.",
+  "listen": {
+    "responses": [
+      {
+        "documentChange": {
+          "document": {
+            "name": "projects/projectID/databases/(default)/documents/C/d1",
+            "fields": {
+              "a": {
+                "integerValue": "3"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          },
+          "targetIds": [
+            1
+          ]
+        }
+      },
+      {
+        "documentChange": {
+          "document": {
+            "name": "projects/projectID/databases/(default)/documents/C/d3",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          },
+          "targetIds": [
+            1
+          ]
+        }
+      },
+      {
+        "documentChange": {
+          "document": {
+            "name": "projects/projectID/databases/(default)/documents/C/d2",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          },
+          "targetIds": [
+            1
+          ]
+        }
+      },
+      {
+        "targetChange": {
+          "targetChangeType": "CURRENT"
+        }
+      },
+      {
+        "targetChange": {
+          "readTime": "1970-01-01T00:00:02Z"
+        }
+      }
+    ],
+    "snapshots": [
+      {
+        "docs": [
+          {
+            "name": "projects/projectID/databases/(default)/documents/C/d2",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          },
+          {
+            "name": "projects/projectID/databases/(default)/documents/C/d3",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          },
+          {
+            "name": "projects/projectID/databases/(default)/documents/C/d1",
+            "fields": {
+              "a": {
+                "integerValue": "3"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          }
+        ],
+        "changes": [
+          {
+            "kind": "ADDED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d2",
+              "fields": {
+                "a": {
+                  "integerValue": "1"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:01Z"
+            },
+            "oldIndex": -1
+          },
+          {
+            "kind": "ADDED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d3",
+              "fields": {
+                "a": {
+                  "integerValue": "1"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:01Z"
+            },
+            "oldIndex": -1,
+            "newIndex": 1
+          },
+          {
+            "kind": "ADDED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d1",
+              "fields": {
+                "a": {
+                  "integerValue": "3"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:01Z"
+            },
+            "oldIndex": -1,
+            "newIndex": 2
+          }
+        ],
+        "readTime": "1970-01-01T00:00:02Z"
+      }
+    ]
+  }
+}

--- a/firestore/v1/testcase/listen-add-three.json
+++ b/firestore/v1/testcase/listen-add-three.json
@@ -1,152 +1,156 @@
 {
-  "description": "listen: add three documents",
-  "comment": "A snapshot with three documents. The documents are sorted\nfirst by the \"a\" field, then by their path. The changes are ordered the same way.",
-  "listen": {
-    "responses": [
-      {
-        "documentChange": {
-          "document": {
-            "name": "projects/projectID/databases/(default)/documents/C/d1",
-            "fields": {
-              "a": {
-                "integerValue": "3"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          },
-          "targetIds": [
-            1
-          ]
-        }
-      },
-      {
-        "documentChange": {
-          "document": {
-            "name": "projects/projectID/databases/(default)/documents/C/d3",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          },
-          "targetIds": [
-            1
-          ]
-        }
-      },
-      {
-        "documentChange": {
-          "document": {
-            "name": "projects/projectID/databases/(default)/documents/C/d2",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          },
-          "targetIds": [
-            1
-          ]
-        }
-      },
-      {
-        "targetChange": {
-          "targetChangeType": "CURRENT"
-        }
-      },
-      {
-        "targetChange": {
-          "readTime": "1970-01-01T00:00:02Z"
-        }
-      }
-    ],
-    "snapshots": [
-      {
-        "docs": [
+  "tests": [
+    {
+      "description": "listen: add three documents",
+      "comment": "A snapshot with three documents. The documents are sorted\nfirst by the \"a\" field, then by their path. The changes are ordered the same way.",
+      "listen": {
+        "responses": [
           {
-            "name": "projects/projectID/databases/(default)/documents/C/d2",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
+            "documentChange": {
+              "document": {
+                "name": "projects/projectID/databases/(default)/documents/C/d1",
+                "fields": {
+                  "a": {
+                    "integerValue": "3"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
+              },
+              "targetIds": [
+                1
+              ]
+            }
           },
           {
-            "name": "projects/projectID/databases/(default)/documents/C/d3",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
+            "documentChange": {
+              "document": {
+                "name": "projects/projectID/databases/(default)/documents/C/d3",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
+              },
+              "targetIds": [
+                1
+              ]
+            }
           },
           {
-            "name": "projects/projectID/databases/(default)/documents/C/d1",
-            "fields": {
-              "a": {
-                "integerValue": "3"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
+            "documentChange": {
+              "document": {
+                "name": "projects/projectID/databases/(default)/documents/C/d2",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
+              },
+              "targetIds": [
+                1
+              ]
+            }
+          },
+          {
+            "targetChange": {
+              "targetChangeType": "CURRENT"
+            }
+          },
+          {
+            "targetChange": {
+              "readTime": "1970-01-01T00:00:02Z"
+            }
           }
         ],
-        "changes": [
+        "snapshots": [
           {
-            "kind": "ADDED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d2",
-              "fields": {
-                "a": {
-                  "integerValue": "1"
-                }
+            "docs": [
+              {
+                "name": "projects/projectID/databases/(default)/documents/C/d2",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
               },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:01Z"
-            },
-            "oldIndex": -1
-          },
-          {
-            "kind": "ADDED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d3",
-              "fields": {
-                "a": {
-                  "integerValue": "1"
-                }
+              {
+                "name": "projects/projectID/databases/(default)/documents/C/d3",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
               },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:01Z"
-            },
-            "oldIndex": -1,
-            "newIndex": 1
-          },
-          {
-            "kind": "ADDED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d1",
-              "fields": {
-                "a": {
-                  "integerValue": "3"
-                }
+              {
+                "name": "projects/projectID/databases/(default)/documents/C/d1",
+                "fields": {
+                  "a": {
+                    "integerValue": "3"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
+              }
+            ],
+            "changes": [
+              {
+                "kind": "ADDED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d2",
+                  "fields": {
+                    "a": {
+                      "integerValue": "1"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:01Z"
+                },
+                "oldIndex": -1
               },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:01Z"
-            },
-            "oldIndex": -1,
-            "newIndex": 2
+              {
+                "kind": "ADDED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d3",
+                  "fields": {
+                    "a": {
+                      "integerValue": "1"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:01Z"
+                },
+                "oldIndex": -1,
+                "newIndex": 1
+              },
+              {
+                "kind": "ADDED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d1",
+                  "fields": {
+                    "a": {
+                      "integerValue": "3"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:01Z"
+                },
+                "oldIndex": -1,
+                "newIndex": 2
+              }
+            ],
+            "readTime": "1970-01-01T00:00:02Z"
           }
-        ],
-        "readTime": "1970-01-01T00:00:02Z"
+        ]
       }
-    ]
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/listen-doc-remove.json
+++ b/firestore/v1/testcase/listen-doc-remove.json
@@ -1,0 +1,97 @@
+{
+  "description": "listen: DocumentRemove behaves like DocumentDelete",
+  "comment": "The DocumentRemove response behaves exactly like DocumentDelete.",
+  "listen": {
+    "responses": [
+      {
+        "documentChange": {
+          "document": {
+            "name": "projects/projectID/databases/(default)/documents/C/d1",
+            "fields": {
+              "a": {
+                "integerValue": "3"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          },
+          "targetIds": [
+            1
+          ]
+        }
+      },
+      {
+        "targetChange": {
+          "targetChangeType": "CURRENT"
+        }
+      },
+      {
+        "targetChange": {
+          "readTime": "1970-01-01T00:00:01Z"
+        }
+      },
+      {
+        "documentRemove": {
+          "document": "projects/projectID/databases/(default)/documents/C/d1"
+        }
+      },
+      {
+        "targetChange": {
+          "readTime": "1970-01-01T00:00:02Z"
+        }
+      }
+    ],
+    "snapshots": [
+      {
+        "docs": [
+          {
+            "name": "projects/projectID/databases/(default)/documents/C/d1",
+            "fields": {
+              "a": {
+                "integerValue": "3"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          }
+        ],
+        "changes": [
+          {
+            "kind": "ADDED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d1",
+              "fields": {
+                "a": {
+                  "integerValue": "3"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:01Z"
+            },
+            "oldIndex": -1
+          }
+        ],
+        "readTime": "1970-01-01T00:00:01Z"
+      },
+      {
+        "changes": [
+          {
+            "kind": "REMOVED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d1",
+              "fields": {
+                "a": {
+                  "integerValue": "3"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:01Z"
+            },
+            "newIndex": -1
+          }
+        ],
+        "readTime": "1970-01-01T00:00:02Z"
+      }
+    ]
+  }
+}

--- a/firestore/v1/testcase/listen-doc-remove.json
+++ b/firestore/v1/testcase/listen-doc-remove.json
@@ -1,97 +1,101 @@
 {
-  "description": "listen: DocumentRemove behaves like DocumentDelete",
-  "comment": "The DocumentRemove response behaves exactly like DocumentDelete.",
-  "listen": {
-    "responses": [
-      {
-        "documentChange": {
-          "document": {
-            "name": "projects/projectID/databases/(default)/documents/C/d1",
-            "fields": {
-              "a": {
-                "integerValue": "3"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
+  "tests": [
+    {
+      "description": "listen: DocumentRemove behaves like DocumentDelete",
+      "comment": "The DocumentRemove response behaves exactly like DocumentDelete.",
+      "listen": {
+        "responses": [
+          {
+            "documentChange": {
+              "document": {
+                "name": "projects/projectID/databases/(default)/documents/C/d1",
+                "fields": {
+                  "a": {
+                    "integerValue": "3"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
+              },
+              "targetIds": [
+                1
+              ]
+            }
           },
-          "targetIds": [
-            1
-          ]
-        }
-      },
-      {
-        "targetChange": {
-          "targetChangeType": "CURRENT"
-        }
-      },
-      {
-        "targetChange": {
-          "readTime": "1970-01-01T00:00:01Z"
-        }
-      },
-      {
-        "documentRemove": {
-          "document": "projects/projectID/databases/(default)/documents/C/d1"
-        }
-      },
-      {
-        "targetChange": {
-          "readTime": "1970-01-01T00:00:02Z"
-        }
-      }
-    ],
-    "snapshots": [
-      {
-        "docs": [
           {
-            "name": "projects/projectID/databases/(default)/documents/C/d1",
-            "fields": {
-              "a": {
-                "integerValue": "3"
+            "targetChange": {
+              "targetChangeType": "CURRENT"
+            }
+          },
+          {
+            "targetChange": {
+              "readTime": "1970-01-01T00:00:01Z"
+            }
+          },
+          {
+            "documentRemove": {
+              "document": "projects/projectID/databases/(default)/documents/C/d1"
+            }
+          },
+          {
+            "targetChange": {
+              "readTime": "1970-01-01T00:00:02Z"
+            }
+          }
+        ],
+        "snapshots": [
+          {
+            "docs": [
+              {
+                "name": "projects/projectID/databases/(default)/documents/C/d1",
+                "fields": {
+                  "a": {
+                    "integerValue": "3"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
               }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          }
-        ],
-        "changes": [
+            ],
+            "changes": [
+              {
+                "kind": "ADDED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d1",
+                  "fields": {
+                    "a": {
+                      "integerValue": "3"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:01Z"
+                },
+                "oldIndex": -1
+              }
+            ],
+            "readTime": "1970-01-01T00:00:01Z"
+          },
           {
-            "kind": "ADDED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d1",
-              "fields": {
-                "a": {
-                  "integerValue": "3"
-                }
-              },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:01Z"
-            },
-            "oldIndex": -1
+            "changes": [
+              {
+                "kind": "REMOVED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d1",
+                  "fields": {
+                    "a": {
+                      "integerValue": "3"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:01Z"
+                },
+                "newIndex": -1
+              }
+            ],
+            "readTime": "1970-01-01T00:00:02Z"
           }
-        ],
-        "readTime": "1970-01-01T00:00:01Z"
-      },
-      {
-        "changes": [
-          {
-            "kind": "REMOVED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d1",
-              "fields": {
-                "a": {
-                  "integerValue": "3"
-                }
-              },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:01Z"
-            },
-            "newIndex": -1
-          }
-        ],
-        "readTime": "1970-01-01T00:00:02Z"
+        ]
       }
-    ]
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/listen-empty.json
+++ b/firestore/v1/testcase/listen-empty.json
@@ -1,0 +1,23 @@
+{
+  "description": "listen: no changes; empty snapshot",
+  "comment": "There are no changes, so the snapshot should be empty.",
+  "listen": {
+    "responses": [
+      {
+        "targetChange": {
+          "targetChangeType": "CURRENT"
+        }
+      },
+      {
+        "targetChange": {
+          "readTime": "1970-01-01T00:00:01Z"
+        }
+      }
+    ],
+    "snapshots": [
+      {
+        "readTime": "1970-01-01T00:00:01Z"
+      }
+    ]
+  }
+}

--- a/firestore/v1/testcase/listen-empty.json
+++ b/firestore/v1/testcase/listen-empty.json
@@ -1,23 +1,27 @@
 {
-  "description": "listen: no changes; empty snapshot",
-  "comment": "There are no changes, so the snapshot should be empty.",
-  "listen": {
-    "responses": [
-      {
-        "targetChange": {
-          "targetChangeType": "CURRENT"
-        }
-      },
-      {
-        "targetChange": {
-          "readTime": "1970-01-01T00:00:01Z"
-        }
+  "tests": [
+    {
+      "description": "listen: no changes; empty snapshot",
+      "comment": "There are no changes, so the snapshot should be empty.",
+      "listen": {
+        "responses": [
+          {
+            "targetChange": {
+              "targetChangeType": "CURRENT"
+            }
+          },
+          {
+            "targetChange": {
+              "readTime": "1970-01-01T00:00:01Z"
+            }
+          }
+        ],
+        "snapshots": [
+          {
+            "readTime": "1970-01-01T00:00:01Z"
+          }
+        ]
       }
-    ],
-    "snapshots": [
-      {
-        "readTime": "1970-01-01T00:00:01Z"
-      }
-    ]
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/listen-filter-nop.json
+++ b/firestore/v1/testcase/listen-filter-nop.json
@@ -1,0 +1,199 @@
+{
+  "description": "listen: Filter response with same size is a no-op",
+  "comment": "A Filter response whose count matches the size of the current\nstate (docs in last snapshot + docs added - docs deleted) is a no-op.",
+  "listen": {
+    "responses": [
+      {
+        "documentChange": {
+          "document": {
+            "name": "projects/projectID/databases/(default)/documents/C/d1",
+            "fields": {
+              "a": {
+                "integerValue": "3"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          },
+          "targetIds": [
+            1
+          ]
+        }
+      },
+      {
+        "documentChange": {
+          "document": {
+            "name": "projects/projectID/databases/(default)/documents/C/d2",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          },
+          "targetIds": [
+            1
+          ]
+        }
+      },
+      {
+        "targetChange": {
+          "targetChangeType": "CURRENT"
+        }
+      },
+      {
+        "targetChange": {
+          "readTime": "1970-01-01T00:00:01Z"
+        }
+      },
+      {
+        "documentChange": {
+          "document": {
+            "name": "projects/projectID/databases/(default)/documents/C/d3",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          },
+          "targetIds": [
+            1
+          ]
+        }
+      },
+      {
+        "documentDelete": {
+          "document": "projects/projectID/databases/(default)/documents/C/d1"
+        }
+      },
+      {
+        "filter": {
+          "count": 2
+        }
+      },
+      {
+        "targetChange": {
+          "readTime": "1970-01-01T00:00:02Z"
+        }
+      }
+    ],
+    "snapshots": [
+      {
+        "docs": [
+          {
+            "name": "projects/projectID/databases/(default)/documents/C/d2",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          },
+          {
+            "name": "projects/projectID/databases/(default)/documents/C/d1",
+            "fields": {
+              "a": {
+                "integerValue": "3"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          }
+        ],
+        "changes": [
+          {
+            "kind": "ADDED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d2",
+              "fields": {
+                "a": {
+                  "integerValue": "1"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:01Z"
+            },
+            "oldIndex": -1
+          },
+          {
+            "kind": "ADDED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d1",
+              "fields": {
+                "a": {
+                  "integerValue": "3"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:01Z"
+            },
+            "oldIndex": -1,
+            "newIndex": 1
+          }
+        ],
+        "readTime": "1970-01-01T00:00:01Z"
+      },
+      {
+        "docs": [
+          {
+            "name": "projects/projectID/databases/(default)/documents/C/d2",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          },
+          {
+            "name": "projects/projectID/databases/(default)/documents/C/d3",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          }
+        ],
+        "changes": [
+          {
+            "kind": "REMOVED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d1",
+              "fields": {
+                "a": {
+                  "integerValue": "3"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:01Z"
+            },
+            "oldIndex": 1,
+            "newIndex": -1
+          },
+          {
+            "kind": "ADDED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d3",
+              "fields": {
+                "a": {
+                  "integerValue": "1"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:01Z"
+            },
+            "oldIndex": -1,
+            "newIndex": 1
+          }
+        ],
+        "readTime": "1970-01-01T00:00:02Z"
+      }
+    ]
+  }
+}

--- a/firestore/v1/testcase/listen-filter-nop.json
+++ b/firestore/v1/testcase/listen-filter-nop.json
@@ -1,199 +1,203 @@
 {
-  "description": "listen: Filter response with same size is a no-op",
-  "comment": "A Filter response whose count matches the size of the current\nstate (docs in last snapshot + docs added - docs deleted) is a no-op.",
-  "listen": {
-    "responses": [
-      {
-        "documentChange": {
-          "document": {
-            "name": "projects/projectID/databases/(default)/documents/C/d1",
-            "fields": {
-              "a": {
-                "integerValue": "3"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
+  "tests": [
+    {
+      "description": "listen: Filter response with same size is a no-op",
+      "comment": "A Filter response whose count matches the size of the current\nstate (docs in last snapshot + docs added - docs deleted) is a no-op.",
+      "listen": {
+        "responses": [
+          {
+            "documentChange": {
+              "document": {
+                "name": "projects/projectID/databases/(default)/documents/C/d1",
+                "fields": {
+                  "a": {
+                    "integerValue": "3"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
+              },
+              "targetIds": [
+                1
+              ]
+            }
           },
-          "targetIds": [
-            1
-          ]
-        }
-      },
-      {
-        "documentChange": {
-          "document": {
-            "name": "projects/projectID/databases/(default)/documents/C/d2",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
+          {
+            "documentChange": {
+              "document": {
+                "name": "projects/projectID/databases/(default)/documents/C/d2",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
+              },
+              "targetIds": [
+                1
+              ]
+            }
           },
-          "targetIds": [
-            1
-          ]
-        }
-      },
-      {
-        "targetChange": {
-          "targetChangeType": "CURRENT"
-        }
-      },
-      {
-        "targetChange": {
-          "readTime": "1970-01-01T00:00:01Z"
-        }
-      },
-      {
-        "documentChange": {
-          "document": {
-            "name": "projects/projectID/databases/(default)/documents/C/d3",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
+          {
+            "targetChange": {
+              "targetChangeType": "CURRENT"
+            }
           },
-          "targetIds": [
-            1
-          ]
-        }
-      },
-      {
-        "documentDelete": {
-          "document": "projects/projectID/databases/(default)/documents/C/d1"
-        }
-      },
-      {
-        "filter": {
-          "count": 2
-        }
-      },
-      {
-        "targetChange": {
-          "readTime": "1970-01-01T00:00:02Z"
-        }
+          {
+            "targetChange": {
+              "readTime": "1970-01-01T00:00:01Z"
+            }
+          },
+          {
+            "documentChange": {
+              "document": {
+                "name": "projects/projectID/databases/(default)/documents/C/d3",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
+              },
+              "targetIds": [
+                1
+              ]
+            }
+          },
+          {
+            "documentDelete": {
+              "document": "projects/projectID/databases/(default)/documents/C/d1"
+            }
+          },
+          {
+            "filter": {
+              "count": 2
+            }
+          },
+          {
+            "targetChange": {
+              "readTime": "1970-01-01T00:00:02Z"
+            }
+          }
+        ],
+        "snapshots": [
+          {
+            "docs": [
+              {
+                "name": "projects/projectID/databases/(default)/documents/C/d2",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
+              },
+              {
+                "name": "projects/projectID/databases/(default)/documents/C/d1",
+                "fields": {
+                  "a": {
+                    "integerValue": "3"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
+              }
+            ],
+            "changes": [
+              {
+                "kind": "ADDED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d2",
+                  "fields": {
+                    "a": {
+                      "integerValue": "1"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:01Z"
+                },
+                "oldIndex": -1
+              },
+              {
+                "kind": "ADDED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d1",
+                  "fields": {
+                    "a": {
+                      "integerValue": "3"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:01Z"
+                },
+                "oldIndex": -1,
+                "newIndex": 1
+              }
+            ],
+            "readTime": "1970-01-01T00:00:01Z"
+          },
+          {
+            "docs": [
+              {
+                "name": "projects/projectID/databases/(default)/documents/C/d2",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
+              },
+              {
+                "name": "projects/projectID/databases/(default)/documents/C/d3",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
+              }
+            ],
+            "changes": [
+              {
+                "kind": "REMOVED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d1",
+                  "fields": {
+                    "a": {
+                      "integerValue": "3"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:01Z"
+                },
+                "oldIndex": 1,
+                "newIndex": -1
+              },
+              {
+                "kind": "ADDED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d3",
+                  "fields": {
+                    "a": {
+                      "integerValue": "1"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:01Z"
+                },
+                "oldIndex": -1,
+                "newIndex": 1
+              }
+            ],
+            "readTime": "1970-01-01T00:00:02Z"
+          }
+        ]
       }
-    ],
-    "snapshots": [
-      {
-        "docs": [
-          {
-            "name": "projects/projectID/databases/(default)/documents/C/d2",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          },
-          {
-            "name": "projects/projectID/databases/(default)/documents/C/d1",
-            "fields": {
-              "a": {
-                "integerValue": "3"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          }
-        ],
-        "changes": [
-          {
-            "kind": "ADDED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d2",
-              "fields": {
-                "a": {
-                  "integerValue": "1"
-                }
-              },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:01Z"
-            },
-            "oldIndex": -1
-          },
-          {
-            "kind": "ADDED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d1",
-              "fields": {
-                "a": {
-                  "integerValue": "3"
-                }
-              },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:01Z"
-            },
-            "oldIndex": -1,
-            "newIndex": 1
-          }
-        ],
-        "readTime": "1970-01-01T00:00:01Z"
-      },
-      {
-        "docs": [
-          {
-            "name": "projects/projectID/databases/(default)/documents/C/d2",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          },
-          {
-            "name": "projects/projectID/databases/(default)/documents/C/d3",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          }
-        ],
-        "changes": [
-          {
-            "kind": "REMOVED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d1",
-              "fields": {
-                "a": {
-                  "integerValue": "3"
-                }
-              },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:01Z"
-            },
-            "oldIndex": 1,
-            "newIndex": -1
-          },
-          {
-            "kind": "ADDED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d3",
-              "fields": {
-                "a": {
-                  "integerValue": "1"
-                }
-              },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:01Z"
-            },
-            "oldIndex": -1,
-            "newIndex": 1
-          }
-        ],
-        "readTime": "1970-01-01T00:00:02Z"
-      }
-    ]
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/listen-multi-docs.json
+++ b/firestore/v1/testcase/listen-multi-docs.json
@@ -1,0 +1,410 @@
+{
+  "description": "listen: multiple documents, added, deleted and updated",
+  "comment": "Changes should be ordered with deletes first, then additions, then mods,\neach in query order.\nOld indices refer to the immediately previous state, not the previous snapshot",
+  "listen": {
+    "responses": [
+      {
+        "documentChange": {
+          "document": {
+            "name": "projects/projectID/databases/(default)/documents/C/d1",
+            "fields": {
+              "a": {
+                "integerValue": "3"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          },
+          "targetIds": [
+            1
+          ]
+        }
+      },
+      {
+        "documentChange": {
+          "document": {
+            "name": "projects/projectID/databases/(default)/documents/C/d3",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          },
+          "targetIds": [
+            1
+          ]
+        }
+      },
+      {
+        "documentChange": {
+          "document": {
+            "name": "projects/projectID/databases/(default)/documents/C/d2",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          },
+          "targetIds": [
+            1
+          ]
+        }
+      },
+      {
+        "documentChange": {
+          "document": {
+            "name": "projects/projectID/databases/(default)/documents/C/d4",
+            "fields": {
+              "a": {
+                "integerValue": "2"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          },
+          "targetIds": [
+            1
+          ]
+        }
+      },
+      {
+        "targetChange": {
+          "targetChangeType": "CURRENT"
+        }
+      },
+      {
+        "targetChange": {
+          "readTime": "1970-01-01T00:00:02Z"
+        }
+      },
+      {
+        "documentChange": {
+          "document": {
+            "name": "projects/projectID/databases/(default)/documents/C/d5",
+            "fields": {
+              "a": {
+                "integerValue": "4"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          },
+          "targetIds": [
+            1
+          ]
+        }
+      },
+      {
+        "documentDelete": {
+          "document": "projects/projectID/databases/(default)/documents/C/d3"
+        }
+      },
+      {
+        "documentChange": {
+          "document": {
+            "name": "projects/projectID/databases/(default)/documents/C/d1",
+            "fields": {
+              "a": {
+                "integerValue": "-1"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:03Z"
+          },
+          "targetIds": [
+            1
+          ]
+        }
+      },
+      {
+        "documentChange": {
+          "document": {
+            "name": "projects/projectID/databases/(default)/documents/C/d6",
+            "fields": {
+              "a": {
+                "integerValue": "3"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          },
+          "targetIds": [
+            1
+          ]
+        }
+      },
+      {
+        "documentDelete": {
+          "document": "projects/projectID/databases/(default)/documents/C/d2"
+        }
+      },
+      {
+        "documentChange": {
+          "document": {
+            "name": "projects/projectID/databases/(default)/documents/C/d4",
+            "fields": {
+              "a": {
+                "integerValue": "-2"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:03Z"
+          },
+          "targetIds": [
+            1
+          ]
+        }
+      },
+      {
+        "targetChange": {
+          "readTime": "1970-01-01T00:00:04Z"
+        }
+      }
+    ],
+    "snapshots": [
+      {
+        "docs": [
+          {
+            "name": "projects/projectID/databases/(default)/documents/C/d2",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          },
+          {
+            "name": "projects/projectID/databases/(default)/documents/C/d3",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          },
+          {
+            "name": "projects/projectID/databases/(default)/documents/C/d4",
+            "fields": {
+              "a": {
+                "integerValue": "2"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          },
+          {
+            "name": "projects/projectID/databases/(default)/documents/C/d1",
+            "fields": {
+              "a": {
+                "integerValue": "3"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          }
+        ],
+        "changes": [
+          {
+            "kind": "ADDED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d2",
+              "fields": {
+                "a": {
+                  "integerValue": "1"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:01Z"
+            },
+            "oldIndex": -1
+          },
+          {
+            "kind": "ADDED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d3",
+              "fields": {
+                "a": {
+                  "integerValue": "1"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:01Z"
+            },
+            "oldIndex": -1,
+            "newIndex": 1
+          },
+          {
+            "kind": "ADDED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d4",
+              "fields": {
+                "a": {
+                  "integerValue": "2"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:01Z"
+            },
+            "oldIndex": -1,
+            "newIndex": 2
+          },
+          {
+            "kind": "ADDED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d1",
+              "fields": {
+                "a": {
+                  "integerValue": "3"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:01Z"
+            },
+            "oldIndex": -1,
+            "newIndex": 3
+          }
+        ],
+        "readTime": "1970-01-01T00:00:02Z"
+      },
+      {
+        "docs": [
+          {
+            "name": "projects/projectID/databases/(default)/documents/C/d4",
+            "fields": {
+              "a": {
+                "integerValue": "-2"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:03Z"
+          },
+          {
+            "name": "projects/projectID/databases/(default)/documents/C/d1",
+            "fields": {
+              "a": {
+                "integerValue": "-1"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:03Z"
+          },
+          {
+            "name": "projects/projectID/databases/(default)/documents/C/d6",
+            "fields": {
+              "a": {
+                "integerValue": "3"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          },
+          {
+            "name": "projects/projectID/databases/(default)/documents/C/d5",
+            "fields": {
+              "a": {
+                "integerValue": "4"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          }
+        ],
+        "changes": [
+          {
+            "kind": "REMOVED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d2",
+              "fields": {
+                "a": {
+                  "integerValue": "1"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:01Z"
+            },
+            "newIndex": -1
+          },
+          {
+            "kind": "REMOVED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d3",
+              "fields": {
+                "a": {
+                  "integerValue": "1"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:01Z"
+            },
+            "newIndex": -1
+          },
+          {
+            "kind": "ADDED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d6",
+              "fields": {
+                "a": {
+                  "integerValue": "3"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:01Z"
+            },
+            "oldIndex": -1,
+            "newIndex": 2
+          },
+          {
+            "kind": "ADDED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d5",
+              "fields": {
+                "a": {
+                  "integerValue": "4"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:01Z"
+            },
+            "oldIndex": -1,
+            "newIndex": 3
+          },
+          {
+            "kind": "MODIFIED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d4",
+              "fields": {
+                "a": {
+                  "integerValue": "-2"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:03Z"
+            }
+          },
+          {
+            "kind": "MODIFIED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d1",
+              "fields": {
+                "a": {
+                  "integerValue": "-1"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:03Z"
+            },
+            "oldIndex": 1,
+            "newIndex": 1
+          }
+        ],
+        "readTime": "1970-01-01T00:00:04Z"
+      }
+    ]
+  }
+}

--- a/firestore/v1/testcase/listen-multi-docs.json
+++ b/firestore/v1/testcase/listen-multi-docs.json
@@ -1,410 +1,414 @@
 {
-  "description": "listen: multiple documents, added, deleted and updated",
-  "comment": "Changes should be ordered with deletes first, then additions, then mods,\neach in query order.\nOld indices refer to the immediately previous state, not the previous snapshot",
-  "listen": {
-    "responses": [
-      {
-        "documentChange": {
-          "document": {
-            "name": "projects/projectID/databases/(default)/documents/C/d1",
-            "fields": {
-              "a": {
-                "integerValue": "3"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          },
-          "targetIds": [
-            1
-          ]
-        }
-      },
-      {
-        "documentChange": {
-          "document": {
-            "name": "projects/projectID/databases/(default)/documents/C/d3",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          },
-          "targetIds": [
-            1
-          ]
-        }
-      },
-      {
-        "documentChange": {
-          "document": {
-            "name": "projects/projectID/databases/(default)/documents/C/d2",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          },
-          "targetIds": [
-            1
-          ]
-        }
-      },
-      {
-        "documentChange": {
-          "document": {
-            "name": "projects/projectID/databases/(default)/documents/C/d4",
-            "fields": {
-              "a": {
-                "integerValue": "2"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          },
-          "targetIds": [
-            1
-          ]
-        }
-      },
-      {
-        "targetChange": {
-          "targetChangeType": "CURRENT"
-        }
-      },
-      {
-        "targetChange": {
-          "readTime": "1970-01-01T00:00:02Z"
-        }
-      },
-      {
-        "documentChange": {
-          "document": {
-            "name": "projects/projectID/databases/(default)/documents/C/d5",
-            "fields": {
-              "a": {
-                "integerValue": "4"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          },
-          "targetIds": [
-            1
-          ]
-        }
-      },
-      {
-        "documentDelete": {
-          "document": "projects/projectID/databases/(default)/documents/C/d3"
-        }
-      },
-      {
-        "documentChange": {
-          "document": {
-            "name": "projects/projectID/databases/(default)/documents/C/d1",
-            "fields": {
-              "a": {
-                "integerValue": "-1"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:03Z"
-          },
-          "targetIds": [
-            1
-          ]
-        }
-      },
-      {
-        "documentChange": {
-          "document": {
-            "name": "projects/projectID/databases/(default)/documents/C/d6",
-            "fields": {
-              "a": {
-                "integerValue": "3"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          },
-          "targetIds": [
-            1
-          ]
-        }
-      },
-      {
-        "documentDelete": {
-          "document": "projects/projectID/databases/(default)/documents/C/d2"
-        }
-      },
-      {
-        "documentChange": {
-          "document": {
-            "name": "projects/projectID/databases/(default)/documents/C/d4",
-            "fields": {
-              "a": {
-                "integerValue": "-2"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:03Z"
-          },
-          "targetIds": [
-            1
-          ]
-        }
-      },
-      {
-        "targetChange": {
-          "readTime": "1970-01-01T00:00:04Z"
-        }
-      }
-    ],
-    "snapshots": [
-      {
-        "docs": [
+  "tests": [
+    {
+      "description": "listen: multiple documents, added, deleted and updated",
+      "comment": "Changes should be ordered with deletes first, then additions, then mods,\neach in query order.\nOld indices refer to the immediately previous state, not the previous snapshot",
+      "listen": {
+        "responses": [
           {
-            "name": "projects/projectID/databases/(default)/documents/C/d2",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          },
-          {
-            "name": "projects/projectID/databases/(default)/documents/C/d3",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          },
-          {
-            "name": "projects/projectID/databases/(default)/documents/C/d4",
-            "fields": {
-              "a": {
-                "integerValue": "2"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          },
-          {
-            "name": "projects/projectID/databases/(default)/documents/C/d1",
-            "fields": {
-              "a": {
-                "integerValue": "3"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          }
-        ],
-        "changes": [
-          {
-            "kind": "ADDED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d2",
-              "fields": {
-                "a": {
-                  "integerValue": "1"
-                }
+            "documentChange": {
+              "document": {
+                "name": "projects/projectID/databases/(default)/documents/C/d1",
+                "fields": {
+                  "a": {
+                    "integerValue": "3"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
               },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:01Z"
-            },
-            "oldIndex": -1
-          },
-          {
-            "kind": "ADDED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d3",
-              "fields": {
-                "a": {
-                  "integerValue": "1"
-                }
-              },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:01Z"
-            },
-            "oldIndex": -1,
-            "newIndex": 1
-          },
-          {
-            "kind": "ADDED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d4",
-              "fields": {
-                "a": {
-                  "integerValue": "2"
-                }
-              },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:01Z"
-            },
-            "oldIndex": -1,
-            "newIndex": 2
-          },
-          {
-            "kind": "ADDED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d1",
-              "fields": {
-                "a": {
-                  "integerValue": "3"
-                }
-              },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:01Z"
-            },
-            "oldIndex": -1,
-            "newIndex": 3
-          }
-        ],
-        "readTime": "1970-01-01T00:00:02Z"
-      },
-      {
-        "docs": [
-          {
-            "name": "projects/projectID/databases/(default)/documents/C/d4",
-            "fields": {
-              "a": {
-                "integerValue": "-2"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:03Z"
-          },
-          {
-            "name": "projects/projectID/databases/(default)/documents/C/d1",
-            "fields": {
-              "a": {
-                "integerValue": "-1"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:03Z"
-          },
-          {
-            "name": "projects/projectID/databases/(default)/documents/C/d6",
-            "fields": {
-              "a": {
-                "integerValue": "3"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          },
-          {
-            "name": "projects/projectID/databases/(default)/documents/C/d5",
-            "fields": {
-              "a": {
-                "integerValue": "4"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          }
-        ],
-        "changes": [
-          {
-            "kind": "REMOVED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d2",
-              "fields": {
-                "a": {
-                  "integerValue": "1"
-                }
-              },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:01Z"
-            },
-            "newIndex": -1
-          },
-          {
-            "kind": "REMOVED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d3",
-              "fields": {
-                "a": {
-                  "integerValue": "1"
-                }
-              },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:01Z"
-            },
-            "newIndex": -1
-          },
-          {
-            "kind": "ADDED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d6",
-              "fields": {
-                "a": {
-                  "integerValue": "3"
-                }
-              },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:01Z"
-            },
-            "oldIndex": -1,
-            "newIndex": 2
-          },
-          {
-            "kind": "ADDED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d5",
-              "fields": {
-                "a": {
-                  "integerValue": "4"
-                }
-              },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:01Z"
-            },
-            "oldIndex": -1,
-            "newIndex": 3
-          },
-          {
-            "kind": "MODIFIED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d4",
-              "fields": {
-                "a": {
-                  "integerValue": "-2"
-                }
-              },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:03Z"
+              "targetIds": [
+                1
+              ]
             }
           },
           {
-            "kind": "MODIFIED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d1",
-              "fields": {
-                "a": {
-                  "integerValue": "-1"
-                }
+            "documentChange": {
+              "document": {
+                "name": "projects/projectID/databases/(default)/documents/C/d3",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
               },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:03Z"
-            },
-            "oldIndex": 1,
-            "newIndex": 1
+              "targetIds": [
+                1
+              ]
+            }
+          },
+          {
+            "documentChange": {
+              "document": {
+                "name": "projects/projectID/databases/(default)/documents/C/d2",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
+              },
+              "targetIds": [
+                1
+              ]
+            }
+          },
+          {
+            "documentChange": {
+              "document": {
+                "name": "projects/projectID/databases/(default)/documents/C/d4",
+                "fields": {
+                  "a": {
+                    "integerValue": "2"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
+              },
+              "targetIds": [
+                1
+              ]
+            }
+          },
+          {
+            "targetChange": {
+              "targetChangeType": "CURRENT"
+            }
+          },
+          {
+            "targetChange": {
+              "readTime": "1970-01-01T00:00:02Z"
+            }
+          },
+          {
+            "documentChange": {
+              "document": {
+                "name": "projects/projectID/databases/(default)/documents/C/d5",
+                "fields": {
+                  "a": {
+                    "integerValue": "4"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
+              },
+              "targetIds": [
+                1
+              ]
+            }
+          },
+          {
+            "documentDelete": {
+              "document": "projects/projectID/databases/(default)/documents/C/d3"
+            }
+          },
+          {
+            "documentChange": {
+              "document": {
+                "name": "projects/projectID/databases/(default)/documents/C/d1",
+                "fields": {
+                  "a": {
+                    "integerValue": "-1"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:03Z"
+              },
+              "targetIds": [
+                1
+              ]
+            }
+          },
+          {
+            "documentChange": {
+              "document": {
+                "name": "projects/projectID/databases/(default)/documents/C/d6",
+                "fields": {
+                  "a": {
+                    "integerValue": "3"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
+              },
+              "targetIds": [
+                1
+              ]
+            }
+          },
+          {
+            "documentDelete": {
+              "document": "projects/projectID/databases/(default)/documents/C/d2"
+            }
+          },
+          {
+            "documentChange": {
+              "document": {
+                "name": "projects/projectID/databases/(default)/documents/C/d4",
+                "fields": {
+                  "a": {
+                    "integerValue": "-2"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:03Z"
+              },
+              "targetIds": [
+                1
+              ]
+            }
+          },
+          {
+            "targetChange": {
+              "readTime": "1970-01-01T00:00:04Z"
+            }
           }
         ],
-        "readTime": "1970-01-01T00:00:04Z"
+        "snapshots": [
+          {
+            "docs": [
+              {
+                "name": "projects/projectID/databases/(default)/documents/C/d2",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
+              },
+              {
+                "name": "projects/projectID/databases/(default)/documents/C/d3",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
+              },
+              {
+                "name": "projects/projectID/databases/(default)/documents/C/d4",
+                "fields": {
+                  "a": {
+                    "integerValue": "2"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
+              },
+              {
+                "name": "projects/projectID/databases/(default)/documents/C/d1",
+                "fields": {
+                  "a": {
+                    "integerValue": "3"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
+              }
+            ],
+            "changes": [
+              {
+                "kind": "ADDED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d2",
+                  "fields": {
+                    "a": {
+                      "integerValue": "1"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:01Z"
+                },
+                "oldIndex": -1
+              },
+              {
+                "kind": "ADDED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d3",
+                  "fields": {
+                    "a": {
+                      "integerValue": "1"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:01Z"
+                },
+                "oldIndex": -1,
+                "newIndex": 1
+              },
+              {
+                "kind": "ADDED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d4",
+                  "fields": {
+                    "a": {
+                      "integerValue": "2"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:01Z"
+                },
+                "oldIndex": -1,
+                "newIndex": 2
+              },
+              {
+                "kind": "ADDED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d1",
+                  "fields": {
+                    "a": {
+                      "integerValue": "3"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:01Z"
+                },
+                "oldIndex": -1,
+                "newIndex": 3
+              }
+            ],
+            "readTime": "1970-01-01T00:00:02Z"
+          },
+          {
+            "docs": [
+              {
+                "name": "projects/projectID/databases/(default)/documents/C/d4",
+                "fields": {
+                  "a": {
+                    "integerValue": "-2"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:03Z"
+              },
+              {
+                "name": "projects/projectID/databases/(default)/documents/C/d1",
+                "fields": {
+                  "a": {
+                    "integerValue": "-1"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:03Z"
+              },
+              {
+                "name": "projects/projectID/databases/(default)/documents/C/d6",
+                "fields": {
+                  "a": {
+                    "integerValue": "3"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
+              },
+              {
+                "name": "projects/projectID/databases/(default)/documents/C/d5",
+                "fields": {
+                  "a": {
+                    "integerValue": "4"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
+              }
+            ],
+            "changes": [
+              {
+                "kind": "REMOVED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d2",
+                  "fields": {
+                    "a": {
+                      "integerValue": "1"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:01Z"
+                },
+                "newIndex": -1
+              },
+              {
+                "kind": "REMOVED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d3",
+                  "fields": {
+                    "a": {
+                      "integerValue": "1"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:01Z"
+                },
+                "newIndex": -1
+              },
+              {
+                "kind": "ADDED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d6",
+                  "fields": {
+                    "a": {
+                      "integerValue": "3"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:01Z"
+                },
+                "oldIndex": -1,
+                "newIndex": 2
+              },
+              {
+                "kind": "ADDED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d5",
+                  "fields": {
+                    "a": {
+                      "integerValue": "4"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:01Z"
+                },
+                "oldIndex": -1,
+                "newIndex": 3
+              },
+              {
+                "kind": "MODIFIED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d4",
+                  "fields": {
+                    "a": {
+                      "integerValue": "-2"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:03Z"
+                }
+              },
+              {
+                "kind": "MODIFIED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d1",
+                  "fields": {
+                    "a": {
+                      "integerValue": "-1"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:03Z"
+                },
+                "oldIndex": 1,
+                "newIndex": 1
+              }
+            ],
+            "readTime": "1970-01-01T00:00:04Z"
+          }
+        ]
       }
-    ]
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/listen-nocurrent.json
+++ b/firestore/v1/testcase/listen-nocurrent.json
@@ -1,0 +1,115 @@
+{
+  "description": "listen: no snapshot if we don't see CURRENT",
+  "comment": "If the watch state is not marked CURRENT, no snapshot is issued.",
+  "listen": {
+    "responses": [
+      {
+        "documentChange": {
+          "document": {
+            "name": "projects/projectID/databases/(default)/documents/C/d1",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          },
+          "targetIds": [
+            1
+          ]
+        }
+      },
+      {
+        "targetChange": {
+          "readTime": "1970-01-01T00:00:01Z"
+        }
+      },
+      {
+        "documentChange": {
+          "document": {
+            "name": "projects/projectID/databases/(default)/documents/C/d2",
+            "fields": {
+              "a": {
+                "integerValue": "2"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:02Z"
+          },
+          "targetIds": [
+            1
+          ]
+        }
+      },
+      {
+        "targetChange": {
+          "targetChangeType": "CURRENT"
+        }
+      },
+      {
+        "targetChange": {
+          "readTime": "1970-01-01T00:00:02Z"
+        }
+      }
+    ],
+    "snapshots": [
+      {
+        "docs": [
+          {
+            "name": "projects/projectID/databases/(default)/documents/C/d1",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          },
+          {
+            "name": "projects/projectID/databases/(default)/documents/C/d2",
+            "fields": {
+              "a": {
+                "integerValue": "2"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:02Z"
+          }
+        ],
+        "changes": [
+          {
+            "kind": "ADDED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d1",
+              "fields": {
+                "a": {
+                  "integerValue": "1"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:01Z"
+            },
+            "oldIndex": -1
+          },
+          {
+            "kind": "ADDED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d2",
+              "fields": {
+                "a": {
+                  "integerValue": "2"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:02Z"
+            },
+            "oldIndex": -1,
+            "newIndex": 1
+          }
+        ],
+        "readTime": "1970-01-01T00:00:02Z"
+      }
+    ]
+  }
+}

--- a/firestore/v1/testcase/listen-nocurrent.json
+++ b/firestore/v1/testcase/listen-nocurrent.json
@@ -1,115 +1,119 @@
 {
-  "description": "listen: no snapshot if we don't see CURRENT",
-  "comment": "If the watch state is not marked CURRENT, no snapshot is issued.",
-  "listen": {
-    "responses": [
-      {
-        "documentChange": {
-          "document": {
-            "name": "projects/projectID/databases/(default)/documents/C/d1",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          },
-          "targetIds": [
-            1
-          ]
-        }
-      },
-      {
-        "targetChange": {
-          "readTime": "1970-01-01T00:00:01Z"
-        }
-      },
-      {
-        "documentChange": {
-          "document": {
-            "name": "projects/projectID/databases/(default)/documents/C/d2",
-            "fields": {
-              "a": {
-                "integerValue": "2"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:02Z"
-          },
-          "targetIds": [
-            1
-          ]
-        }
-      },
-      {
-        "targetChange": {
-          "targetChangeType": "CURRENT"
-        }
-      },
-      {
-        "targetChange": {
-          "readTime": "1970-01-01T00:00:02Z"
-        }
-      }
-    ],
-    "snapshots": [
-      {
-        "docs": [
+  "tests": [
+    {
+      "description": "listen: no snapshot if we don't see CURRENT",
+      "comment": "If the watch state is not marked CURRENT, no snapshot is issued.",
+      "listen": {
+        "responses": [
           {
-            "name": "projects/projectID/databases/(default)/documents/C/d1",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
+            "documentChange": {
+              "document": {
+                "name": "projects/projectID/databases/(default)/documents/C/d1",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
+              },
+              "targetIds": [
+                1
+              ]
+            }
           },
           {
-            "name": "projects/projectID/databases/(default)/documents/C/d2",
-            "fields": {
-              "a": {
-                "integerValue": "2"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:02Z"
+            "targetChange": {
+              "readTime": "1970-01-01T00:00:01Z"
+            }
+          },
+          {
+            "documentChange": {
+              "document": {
+                "name": "projects/projectID/databases/(default)/documents/C/d2",
+                "fields": {
+                  "a": {
+                    "integerValue": "2"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:02Z"
+              },
+              "targetIds": [
+                1
+              ]
+            }
+          },
+          {
+            "targetChange": {
+              "targetChangeType": "CURRENT"
+            }
+          },
+          {
+            "targetChange": {
+              "readTime": "1970-01-01T00:00:02Z"
+            }
           }
         ],
-        "changes": [
+        "snapshots": [
           {
-            "kind": "ADDED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d1",
-              "fields": {
-                "a": {
-                  "integerValue": "1"
-                }
+            "docs": [
+              {
+                "name": "projects/projectID/databases/(default)/documents/C/d1",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
               },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:01Z"
-            },
-            "oldIndex": -1
-          },
-          {
-            "kind": "ADDED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d2",
-              "fields": {
-                "a": {
-                  "integerValue": "2"
-                }
+              {
+                "name": "projects/projectID/databases/(default)/documents/C/d2",
+                "fields": {
+                  "a": {
+                    "integerValue": "2"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:02Z"
+              }
+            ],
+            "changes": [
+              {
+                "kind": "ADDED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d1",
+                  "fields": {
+                    "a": {
+                      "integerValue": "1"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:01Z"
+                },
+                "oldIndex": -1
               },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:02Z"
-            },
-            "oldIndex": -1,
-            "newIndex": 1
+              {
+                "kind": "ADDED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d2",
+                  "fields": {
+                    "a": {
+                      "integerValue": "2"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:02Z"
+                },
+                "oldIndex": -1,
+                "newIndex": 1
+              }
+            ],
+            "readTime": "1970-01-01T00:00:02Z"
           }
-        ],
-        "readTime": "1970-01-01T00:00:02Z"
+        ]
       }
-    ]
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/listen-nomod.json
+++ b/firestore/v1/testcase/listen-nomod.json
@@ -1,0 +1,119 @@
+{
+  "description": "listen: add a doc, then change it but without changing its update time",
+  "comment": "Document updates are recognized by a change in the update time, not the data.\nThis shouldn't actually happen. It is just a test of the update logic.",
+  "listen": {
+    "responses": [
+      {
+        "documentChange": {
+          "document": {
+            "name": "projects/projectID/databases/(default)/documents/C/d1",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          },
+          "targetIds": [
+            1
+          ]
+        }
+      },
+      {
+        "targetChange": {
+          "targetChangeType": "CURRENT"
+        }
+      },
+      {
+        "targetChange": {
+          "readTime": "1970-01-01T00:00:01Z"
+        }
+      },
+      {
+        "documentChange": {
+          "document": {
+            "name": "projects/projectID/databases/(default)/documents/C/d1",
+            "fields": {
+              "a": {
+                "integerValue": "2"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          },
+          "targetIds": [
+            1
+          ]
+        }
+      },
+      {
+        "targetChange": {
+          "readTime": "1970-01-01T00:00:02Z"
+        }
+      },
+      {
+        "documentDelete": {
+          "document": "projects/projectID/databases/(default)/documents/C/d1"
+        }
+      },
+      {
+        "targetChange": {
+          "readTime": "1970-01-01T00:00:03Z"
+        }
+      }
+    ],
+    "snapshots": [
+      {
+        "docs": [
+          {
+            "name": "projects/projectID/databases/(default)/documents/C/d1",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          }
+        ],
+        "changes": [
+          {
+            "kind": "ADDED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d1",
+              "fields": {
+                "a": {
+                  "integerValue": "1"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:01Z"
+            },
+            "oldIndex": -1
+          }
+        ],
+        "readTime": "1970-01-01T00:00:01Z"
+      },
+      {
+        "changes": [
+          {
+            "kind": "REMOVED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d1",
+              "fields": {
+                "a": {
+                  "integerValue": "1"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:01Z"
+            },
+            "newIndex": -1
+          }
+        ],
+        "readTime": "1970-01-01T00:00:03Z"
+      }
+    ]
+  }
+}

--- a/firestore/v1/testcase/listen-nomod.json
+++ b/firestore/v1/testcase/listen-nomod.json
@@ -1,119 +1,123 @@
 {
-  "description": "listen: add a doc, then change it but without changing its update time",
-  "comment": "Document updates are recognized by a change in the update time, not the data.\nThis shouldn't actually happen. It is just a test of the update logic.",
-  "listen": {
-    "responses": [
-      {
-        "documentChange": {
-          "document": {
-            "name": "projects/projectID/databases/(default)/documents/C/d1",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          },
-          "targetIds": [
-            1
-          ]
-        }
-      },
-      {
-        "targetChange": {
-          "targetChangeType": "CURRENT"
-        }
-      },
-      {
-        "targetChange": {
-          "readTime": "1970-01-01T00:00:01Z"
-        }
-      },
-      {
-        "documentChange": {
-          "document": {
-            "name": "projects/projectID/databases/(default)/documents/C/d1",
-            "fields": {
-              "a": {
-                "integerValue": "2"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          },
-          "targetIds": [
-            1
-          ]
-        }
-      },
-      {
-        "targetChange": {
-          "readTime": "1970-01-01T00:00:02Z"
-        }
-      },
-      {
-        "documentDelete": {
-          "document": "projects/projectID/databases/(default)/documents/C/d1"
-        }
-      },
-      {
-        "targetChange": {
-          "readTime": "1970-01-01T00:00:03Z"
-        }
-      }
-    ],
-    "snapshots": [
-      {
-        "docs": [
+  "tests": [
+    {
+      "description": "listen: add a doc, then change it but without changing its update time",
+      "comment": "Document updates are recognized by a change in the update time, not the data.\nThis shouldn't actually happen. It is just a test of the update logic.",
+      "listen": {
+        "responses": [
           {
-            "name": "projects/projectID/databases/(default)/documents/C/d1",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          }
-        ],
-        "changes": [
-          {
-            "kind": "ADDED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d1",
-              "fields": {
-                "a": {
-                  "integerValue": "1"
-                }
+            "documentChange": {
+              "document": {
+                "name": "projects/projectID/databases/(default)/documents/C/d1",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
               },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:01Z"
-            },
-            "oldIndex": -1
-          }
-        ],
-        "readTime": "1970-01-01T00:00:01Z"
-      },
-      {
-        "changes": [
+              "targetIds": [
+                1
+              ]
+            }
+          },
           {
-            "kind": "REMOVED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d1",
-              "fields": {
-                "a": {
-                  "integerValue": "1"
-                }
+            "targetChange": {
+              "targetChangeType": "CURRENT"
+            }
+          },
+          {
+            "targetChange": {
+              "readTime": "1970-01-01T00:00:01Z"
+            }
+          },
+          {
+            "documentChange": {
+              "document": {
+                "name": "projects/projectID/databases/(default)/documents/C/d1",
+                "fields": {
+                  "a": {
+                    "integerValue": "2"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
               },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:01Z"
-            },
-            "newIndex": -1
+              "targetIds": [
+                1
+              ]
+            }
+          },
+          {
+            "targetChange": {
+              "readTime": "1970-01-01T00:00:02Z"
+            }
+          },
+          {
+            "documentDelete": {
+              "document": "projects/projectID/databases/(default)/documents/C/d1"
+            }
+          },
+          {
+            "targetChange": {
+              "readTime": "1970-01-01T00:00:03Z"
+            }
           }
         ],
-        "readTime": "1970-01-01T00:00:03Z"
+        "snapshots": [
+          {
+            "docs": [
+              {
+                "name": "projects/projectID/databases/(default)/documents/C/d1",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
+              }
+            ],
+            "changes": [
+              {
+                "kind": "ADDED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d1",
+                  "fields": {
+                    "a": {
+                      "integerValue": "1"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:01Z"
+                },
+                "oldIndex": -1
+              }
+            ],
+            "readTime": "1970-01-01T00:00:01Z"
+          },
+          {
+            "changes": [
+              {
+                "kind": "REMOVED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d1",
+                  "fields": {
+                    "a": {
+                      "integerValue": "1"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:01Z"
+                },
+                "newIndex": -1
+              }
+            ],
+            "readTime": "1970-01-01T00:00:03Z"
+          }
+        ]
       }
-    ]
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/listen-removed-target-ids.json
+++ b/firestore/v1/testcase/listen-removed-target-ids.json
@@ -1,0 +1,109 @@
+{
+  "description": "listen: DocumentChange with removed_target_id is like a delete.",
+  "comment": "A DocumentChange with the watch target ID in the removed_target_ids field is the\nsame as deleting a document.",
+  "listen": {
+    "responses": [
+      {
+        "documentChange": {
+          "document": {
+            "name": "projects/projectID/databases/(default)/documents/C/d1",
+            "fields": {
+              "a": {
+                "integerValue": "3"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          },
+          "targetIds": [
+            1
+          ]
+        }
+      },
+      {
+        "targetChange": {
+          "targetChangeType": "CURRENT"
+        }
+      },
+      {
+        "targetChange": {
+          "readTime": "1970-01-01T00:00:01Z"
+        }
+      },
+      {
+        "documentChange": {
+          "document": {
+            "name": "projects/projectID/databases/(default)/documents/C/d1",
+            "fields": {
+              "a": {
+                "integerValue": "3"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          },
+          "removedTargetIds": [
+            1
+          ]
+        }
+      },
+      {
+        "targetChange": {
+          "readTime": "1970-01-01T00:00:02Z"
+        }
+      }
+    ],
+    "snapshots": [
+      {
+        "docs": [
+          {
+            "name": "projects/projectID/databases/(default)/documents/C/d1",
+            "fields": {
+              "a": {
+                "integerValue": "3"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          }
+        ],
+        "changes": [
+          {
+            "kind": "ADDED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d1",
+              "fields": {
+                "a": {
+                  "integerValue": "3"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:01Z"
+            },
+            "oldIndex": -1
+          }
+        ],
+        "readTime": "1970-01-01T00:00:01Z"
+      },
+      {
+        "changes": [
+          {
+            "kind": "REMOVED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d1",
+              "fields": {
+                "a": {
+                  "integerValue": "3"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:01Z"
+            },
+            "newIndex": -1
+          }
+        ],
+        "readTime": "1970-01-01T00:00:02Z"
+      }
+    ]
+  }
+}

--- a/firestore/v1/testcase/listen-removed-target-ids.json
+++ b/firestore/v1/testcase/listen-removed-target-ids.json
@@ -1,109 +1,113 @@
 {
-  "description": "listen: DocumentChange with removed_target_id is like a delete.",
-  "comment": "A DocumentChange with the watch target ID in the removed_target_ids field is the\nsame as deleting a document.",
-  "listen": {
-    "responses": [
-      {
-        "documentChange": {
-          "document": {
-            "name": "projects/projectID/databases/(default)/documents/C/d1",
-            "fields": {
-              "a": {
-                "integerValue": "3"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          },
-          "targetIds": [
-            1
-          ]
-        }
-      },
-      {
-        "targetChange": {
-          "targetChangeType": "CURRENT"
-        }
-      },
-      {
-        "targetChange": {
-          "readTime": "1970-01-01T00:00:01Z"
-        }
-      },
-      {
-        "documentChange": {
-          "document": {
-            "name": "projects/projectID/databases/(default)/documents/C/d1",
-            "fields": {
-              "a": {
-                "integerValue": "3"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          },
-          "removedTargetIds": [
-            1
-          ]
-        }
-      },
-      {
-        "targetChange": {
-          "readTime": "1970-01-01T00:00:02Z"
-        }
-      }
-    ],
-    "snapshots": [
-      {
-        "docs": [
+  "tests": [
+    {
+      "description": "listen: DocumentChange with removed_target_id is like a delete.",
+      "comment": "A DocumentChange with the watch target ID in the removed_target_ids field is the\nsame as deleting a document.",
+      "listen": {
+        "responses": [
           {
-            "name": "projects/projectID/databases/(default)/documents/C/d1",
-            "fields": {
-              "a": {
-                "integerValue": "3"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          }
-        ],
-        "changes": [
-          {
-            "kind": "ADDED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d1",
-              "fields": {
-                "a": {
-                  "integerValue": "3"
-                }
+            "documentChange": {
+              "document": {
+                "name": "projects/projectID/databases/(default)/documents/C/d1",
+                "fields": {
+                  "a": {
+                    "integerValue": "3"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
               },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:01Z"
-            },
-            "oldIndex": -1
-          }
-        ],
-        "readTime": "1970-01-01T00:00:01Z"
-      },
-      {
-        "changes": [
+              "targetIds": [
+                1
+              ]
+            }
+          },
           {
-            "kind": "REMOVED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d1",
-              "fields": {
-                "a": {
-                  "integerValue": "3"
-                }
+            "targetChange": {
+              "targetChangeType": "CURRENT"
+            }
+          },
+          {
+            "targetChange": {
+              "readTime": "1970-01-01T00:00:01Z"
+            }
+          },
+          {
+            "documentChange": {
+              "document": {
+                "name": "projects/projectID/databases/(default)/documents/C/d1",
+                "fields": {
+                  "a": {
+                    "integerValue": "3"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
               },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:01Z"
-            },
-            "newIndex": -1
+              "removedTargetIds": [
+                1
+              ]
+            }
+          },
+          {
+            "targetChange": {
+              "readTime": "1970-01-01T00:00:02Z"
+            }
           }
         ],
-        "readTime": "1970-01-01T00:00:02Z"
+        "snapshots": [
+          {
+            "docs": [
+              {
+                "name": "projects/projectID/databases/(default)/documents/C/d1",
+                "fields": {
+                  "a": {
+                    "integerValue": "3"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
+              }
+            ],
+            "changes": [
+              {
+                "kind": "ADDED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d1",
+                  "fields": {
+                    "a": {
+                      "integerValue": "3"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:01Z"
+                },
+                "oldIndex": -1
+              }
+            ],
+            "readTime": "1970-01-01T00:00:01Z"
+          },
+          {
+            "changes": [
+              {
+                "kind": "REMOVED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d1",
+                  "fields": {
+                    "a": {
+                      "integerValue": "3"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:01Z"
+                },
+                "newIndex": -1
+              }
+            ],
+            "readTime": "1970-01-01T00:00:02Z"
+          }
+        ]
       }
-    ]
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/listen-reset.json
+++ b/firestore/v1/testcase/listen-reset.json
@@ -1,0 +1,305 @@
+{
+  "description": "listen: RESET turns off CURRENT",
+  "comment": "A RESET message turns off the CURRENT state, and marks all documents as deleted.\n\nIf a document appeared on the stream but was never part of a snapshot (\"d3\" in this test), a reset\nwill make it disappear completely.\n\nFor a snapshot to happen at a NO_CHANGE reponse, we need to have both seen a CURRENT response, and\nhave a change from the previous snapshot. Here, after the reset, we see the same version of d2\nagain. That doesn't result in a snapshot.\n",
+  "listen": {
+    "responses": [
+      {
+        "documentChange": {
+          "document": {
+            "name": "projects/projectID/databases/(default)/documents/C/d1",
+            "fields": {
+              "a": {
+                "integerValue": "2"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          },
+          "targetIds": [
+            1
+          ]
+        }
+      },
+      {
+        "documentChange": {
+          "document": {
+            "name": "projects/projectID/databases/(default)/documents/C/d2",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:02Z"
+          },
+          "targetIds": [
+            1
+          ]
+        }
+      },
+      {
+        "targetChange": {
+          "targetChangeType": "CURRENT"
+        }
+      },
+      {
+        "targetChange": {
+          "readTime": "1970-01-01T00:00:01Z"
+        }
+      },
+      {
+        "documentChange": {
+          "document": {
+            "name": "projects/projectID/databases/(default)/documents/C/d3",
+            "fields": {
+              "a": {
+                "integerValue": "3"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:02Z"
+          },
+          "targetIds": [
+            1
+          ]
+        }
+      },
+      {
+        "targetChange": {
+          "targetChangeType": "RESET"
+        }
+      },
+      {
+        "targetChange": {
+          "readTime": "1970-01-01T00:00:02Z"
+        }
+      },
+      {
+        "targetChange": {
+          "targetChangeType": "CURRENT"
+        }
+      },
+      {
+        "documentChange": {
+          "document": {
+            "name": "projects/projectID/databases/(default)/documents/C/d2",
+            "fields": {
+              "a": {
+                "integerValue": "3"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:03Z"
+          },
+          "targetIds": [
+            1
+          ]
+        }
+      },
+      {
+        "targetChange": {
+          "readTime": "1970-01-01T00:00:03Z"
+        }
+      },
+      {
+        "targetChange": {
+          "targetChangeType": "RESET"
+        }
+      },
+      {
+        "documentChange": {
+          "document": {
+            "name": "projects/projectID/databases/(default)/documents/C/d2",
+            "fields": {
+              "a": {
+                "integerValue": "3"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:03Z"
+          },
+          "targetIds": [
+            1
+          ]
+        }
+      },
+      {
+        "targetChange": {
+          "targetChangeType": "CURRENT"
+        }
+      },
+      {
+        "targetChange": {
+          "readTime": "1970-01-01T00:00:04Z"
+        }
+      },
+      {
+        "documentChange": {
+          "document": {
+            "name": "projects/projectID/databases/(default)/documents/C/d3",
+            "fields": {
+              "a": {
+                "integerValue": "3"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:02Z"
+          },
+          "targetIds": [
+            1
+          ]
+        }
+      },
+      {
+        "targetChange": {
+          "readTime": "1970-01-01T00:00:05Z"
+        }
+      }
+    ],
+    "snapshots": [
+      {
+        "docs": [
+          {
+            "name": "projects/projectID/databases/(default)/documents/C/d2",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:02Z"
+          },
+          {
+            "name": "projects/projectID/databases/(default)/documents/C/d1",
+            "fields": {
+              "a": {
+                "integerValue": "2"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          }
+        ],
+        "changes": [
+          {
+            "kind": "ADDED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d2",
+              "fields": {
+                "a": {
+                  "integerValue": "1"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:02Z"
+            },
+            "oldIndex": -1
+          },
+          {
+            "kind": "ADDED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d1",
+              "fields": {
+                "a": {
+                  "integerValue": "2"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:01Z"
+            },
+            "oldIndex": -1,
+            "newIndex": 1
+          }
+        ],
+        "readTime": "1970-01-01T00:00:01Z"
+      },
+      {
+        "docs": [
+          {
+            "name": "projects/projectID/databases/(default)/documents/C/d2",
+            "fields": {
+              "a": {
+                "integerValue": "3"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:03Z"
+          }
+        ],
+        "changes": [
+          {
+            "kind": "REMOVED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d1",
+              "fields": {
+                "a": {
+                  "integerValue": "2"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:01Z"
+            },
+            "oldIndex": 1,
+            "newIndex": -1
+          },
+          {
+            "kind": "MODIFIED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d2",
+              "fields": {
+                "a": {
+                  "integerValue": "3"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:03Z"
+            }
+          }
+        ],
+        "readTime": "1970-01-01T00:00:03Z"
+      },
+      {
+        "docs": [
+          {
+            "name": "projects/projectID/databases/(default)/documents/C/d2",
+            "fields": {
+              "a": {
+                "integerValue": "3"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:03Z"
+          },
+          {
+            "name": "projects/projectID/databases/(default)/documents/C/d3",
+            "fields": {
+              "a": {
+                "integerValue": "3"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:02Z"
+          }
+        ],
+        "changes": [
+          {
+            "kind": "ADDED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d3",
+              "fields": {
+                "a": {
+                  "integerValue": "3"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:02Z"
+            },
+            "oldIndex": -1,
+            "newIndex": 1
+          }
+        ],
+        "readTime": "1970-01-01T00:00:05Z"
+      }
+    ]
+  }
+}

--- a/firestore/v1/testcase/listen-reset.json
+++ b/firestore/v1/testcase/listen-reset.json
@@ -1,305 +1,309 @@
 {
-  "description": "listen: RESET turns off CURRENT",
-  "comment": "A RESET message turns off the CURRENT state, and marks all documents as deleted.\n\nIf a document appeared on the stream but was never part of a snapshot (\"d3\" in this test), a reset\nwill make it disappear completely.\n\nFor a snapshot to happen at a NO_CHANGE reponse, we need to have both seen a CURRENT response, and\nhave a change from the previous snapshot. Here, after the reset, we see the same version of d2\nagain. That doesn't result in a snapshot.\n",
-  "listen": {
-    "responses": [
-      {
-        "documentChange": {
-          "document": {
-            "name": "projects/projectID/databases/(default)/documents/C/d1",
-            "fields": {
-              "a": {
-                "integerValue": "2"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          },
-          "targetIds": [
-            1
-          ]
-        }
-      },
-      {
-        "documentChange": {
-          "document": {
-            "name": "projects/projectID/databases/(default)/documents/C/d2",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:02Z"
-          },
-          "targetIds": [
-            1
-          ]
-        }
-      },
-      {
-        "targetChange": {
-          "targetChangeType": "CURRENT"
-        }
-      },
-      {
-        "targetChange": {
-          "readTime": "1970-01-01T00:00:01Z"
-        }
-      },
-      {
-        "documentChange": {
-          "document": {
-            "name": "projects/projectID/databases/(default)/documents/C/d3",
-            "fields": {
-              "a": {
-                "integerValue": "3"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:02Z"
-          },
-          "targetIds": [
-            1
-          ]
-        }
-      },
-      {
-        "targetChange": {
-          "targetChangeType": "RESET"
-        }
-      },
-      {
-        "targetChange": {
-          "readTime": "1970-01-01T00:00:02Z"
-        }
-      },
-      {
-        "targetChange": {
-          "targetChangeType": "CURRENT"
-        }
-      },
-      {
-        "documentChange": {
-          "document": {
-            "name": "projects/projectID/databases/(default)/documents/C/d2",
-            "fields": {
-              "a": {
-                "integerValue": "3"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:03Z"
-          },
-          "targetIds": [
-            1
-          ]
-        }
-      },
-      {
-        "targetChange": {
-          "readTime": "1970-01-01T00:00:03Z"
-        }
-      },
-      {
-        "targetChange": {
-          "targetChangeType": "RESET"
-        }
-      },
-      {
-        "documentChange": {
-          "document": {
-            "name": "projects/projectID/databases/(default)/documents/C/d2",
-            "fields": {
-              "a": {
-                "integerValue": "3"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:03Z"
-          },
-          "targetIds": [
-            1
-          ]
-        }
-      },
-      {
-        "targetChange": {
-          "targetChangeType": "CURRENT"
-        }
-      },
-      {
-        "targetChange": {
-          "readTime": "1970-01-01T00:00:04Z"
-        }
-      },
-      {
-        "documentChange": {
-          "document": {
-            "name": "projects/projectID/databases/(default)/documents/C/d3",
-            "fields": {
-              "a": {
-                "integerValue": "3"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:02Z"
-          },
-          "targetIds": [
-            1
-          ]
-        }
-      },
-      {
-        "targetChange": {
-          "readTime": "1970-01-01T00:00:05Z"
-        }
-      }
-    ],
-    "snapshots": [
-      {
-        "docs": [
+  "tests": [
+    {
+      "description": "listen: RESET turns off CURRENT",
+      "comment": "A RESET message turns off the CURRENT state, and marks all documents as deleted.\n\nIf a document appeared on the stream but was never part of a snapshot (\"d3\" in this test), a reset\nwill make it disappear completely.\n\nFor a snapshot to happen at a NO_CHANGE reponse, we need to have both seen a CURRENT response, and\nhave a change from the previous snapshot. Here, after the reset, we see the same version of d2\nagain. That doesn't result in a snapshot.\n",
+      "listen": {
+        "responses": [
           {
-            "name": "projects/projectID/databases/(default)/documents/C/d2",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:02Z"
-          },
-          {
-            "name": "projects/projectID/databases/(default)/documents/C/d1",
-            "fields": {
-              "a": {
-                "integerValue": "2"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          }
-        ],
-        "changes": [
-          {
-            "kind": "ADDED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d2",
-              "fields": {
-                "a": {
-                  "integerValue": "1"
-                }
+            "documentChange": {
+              "document": {
+                "name": "projects/projectID/databases/(default)/documents/C/d1",
+                "fields": {
+                  "a": {
+                    "integerValue": "2"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
               },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:02Z"
-            },
-            "oldIndex": -1
+              "targetIds": [
+                1
+              ]
+            }
           },
           {
-            "kind": "ADDED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d1",
-              "fields": {
-                "a": {
-                  "integerValue": "2"
-                }
+            "documentChange": {
+              "document": {
+                "name": "projects/projectID/databases/(default)/documents/C/d2",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:02Z"
               },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:01Z"
-            },
-            "oldIndex": -1,
-            "newIndex": 1
-          }
-        ],
-        "readTime": "1970-01-01T00:00:01Z"
-      },
-      {
-        "docs": [
-          {
-            "name": "projects/projectID/databases/(default)/documents/C/d2",
-            "fields": {
-              "a": {
-                "integerValue": "3"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:03Z"
-          }
-        ],
-        "changes": [
-          {
-            "kind": "REMOVED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d1",
-              "fields": {
-                "a": {
-                  "integerValue": "2"
-                }
-              },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:01Z"
-            },
-            "oldIndex": 1,
-            "newIndex": -1
+              "targetIds": [
+                1
+              ]
+            }
           },
           {
-            "kind": "MODIFIED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d2",
-              "fields": {
-                "a": {
-                  "integerValue": "3"
-                }
+            "targetChange": {
+              "targetChangeType": "CURRENT"
+            }
+          },
+          {
+            "targetChange": {
+              "readTime": "1970-01-01T00:00:01Z"
+            }
+          },
+          {
+            "documentChange": {
+              "document": {
+                "name": "projects/projectID/databases/(default)/documents/C/d3",
+                "fields": {
+                  "a": {
+                    "integerValue": "3"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:02Z"
               },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:03Z"
+              "targetIds": [
+                1
+              ]
+            }
+          },
+          {
+            "targetChange": {
+              "targetChangeType": "RESET"
+            }
+          },
+          {
+            "targetChange": {
+              "readTime": "1970-01-01T00:00:02Z"
+            }
+          },
+          {
+            "targetChange": {
+              "targetChangeType": "CURRENT"
+            }
+          },
+          {
+            "documentChange": {
+              "document": {
+                "name": "projects/projectID/databases/(default)/documents/C/d2",
+                "fields": {
+                  "a": {
+                    "integerValue": "3"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:03Z"
+              },
+              "targetIds": [
+                1
+              ]
+            }
+          },
+          {
+            "targetChange": {
+              "readTime": "1970-01-01T00:00:03Z"
+            }
+          },
+          {
+            "targetChange": {
+              "targetChangeType": "RESET"
+            }
+          },
+          {
+            "documentChange": {
+              "document": {
+                "name": "projects/projectID/databases/(default)/documents/C/d2",
+                "fields": {
+                  "a": {
+                    "integerValue": "3"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:03Z"
+              },
+              "targetIds": [
+                1
+              ]
+            }
+          },
+          {
+            "targetChange": {
+              "targetChangeType": "CURRENT"
+            }
+          },
+          {
+            "targetChange": {
+              "readTime": "1970-01-01T00:00:04Z"
+            }
+          },
+          {
+            "documentChange": {
+              "document": {
+                "name": "projects/projectID/databases/(default)/documents/C/d3",
+                "fields": {
+                  "a": {
+                    "integerValue": "3"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:02Z"
+              },
+              "targetIds": [
+                1
+              ]
+            }
+          },
+          {
+            "targetChange": {
+              "readTime": "1970-01-01T00:00:05Z"
             }
           }
         ],
-        "readTime": "1970-01-01T00:00:03Z"
-      },
-      {
-        "docs": [
+        "snapshots": [
           {
-            "name": "projects/projectID/databases/(default)/documents/C/d2",
-            "fields": {
-              "a": {
-                "integerValue": "3"
+            "docs": [
+              {
+                "name": "projects/projectID/databases/(default)/documents/C/d2",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:02Z"
+              },
+              {
+                "name": "projects/projectID/databases/(default)/documents/C/d1",
+                "fields": {
+                  "a": {
+                    "integerValue": "2"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
               }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:03Z"
+            ],
+            "changes": [
+              {
+                "kind": "ADDED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d2",
+                  "fields": {
+                    "a": {
+                      "integerValue": "1"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:02Z"
+                },
+                "oldIndex": -1
+              },
+              {
+                "kind": "ADDED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d1",
+                  "fields": {
+                    "a": {
+                      "integerValue": "2"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:01Z"
+                },
+                "oldIndex": -1,
+                "newIndex": 1
+              }
+            ],
+            "readTime": "1970-01-01T00:00:01Z"
           },
           {
-            "name": "projects/projectID/databases/(default)/documents/C/d3",
-            "fields": {
-              "a": {
-                "integerValue": "3"
+            "docs": [
+              {
+                "name": "projects/projectID/databases/(default)/documents/C/d2",
+                "fields": {
+                  "a": {
+                    "integerValue": "3"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:03Z"
               }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:02Z"
-          }
-        ],
-        "changes": [
-          {
-            "kind": "ADDED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d3",
-              "fields": {
-                "a": {
-                  "integerValue": "3"
-                }
+            ],
+            "changes": [
+              {
+                "kind": "REMOVED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d1",
+                  "fields": {
+                    "a": {
+                      "integerValue": "2"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:01Z"
+                },
+                "oldIndex": 1,
+                "newIndex": -1
               },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:02Z"
-            },
-            "oldIndex": -1,
-            "newIndex": 1
+              {
+                "kind": "MODIFIED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d2",
+                  "fields": {
+                    "a": {
+                      "integerValue": "3"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:03Z"
+                }
+              }
+            ],
+            "readTime": "1970-01-01T00:00:03Z"
+          },
+          {
+            "docs": [
+              {
+                "name": "projects/projectID/databases/(default)/documents/C/d2",
+                "fields": {
+                  "a": {
+                    "integerValue": "3"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:03Z"
+              },
+              {
+                "name": "projects/projectID/databases/(default)/documents/C/d3",
+                "fields": {
+                  "a": {
+                    "integerValue": "3"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:02Z"
+              }
+            ],
+            "changes": [
+              {
+                "kind": "ADDED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d3",
+                  "fields": {
+                    "a": {
+                      "integerValue": "3"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:02Z"
+                },
+                "oldIndex": -1,
+                "newIndex": 1
+              }
+            ],
+            "readTime": "1970-01-01T00:00:05Z"
           }
-        ],
-        "readTime": "1970-01-01T00:00:05Z"
+        ]
       }
-    ]
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/listen-target-add-nop.json
+++ b/firestore/v1/testcase/listen-target-add-nop.json
@@ -1,0 +1,77 @@
+{
+  "description": "listen: TargetChange_ADD is a no-op if it has the same target ID",
+  "comment": "A TargetChange_ADD response must have the same watch target ID.",
+  "listen": {
+    "responses": [
+      {
+        "documentChange": {
+          "document": {
+            "name": "projects/projectID/databases/(default)/documents/C/d1",
+            "fields": {
+              "a": {
+                "integerValue": "3"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          },
+          "targetIds": [
+            1
+          ]
+        }
+      },
+      {
+        "targetChange": {
+          "targetChangeType": "CURRENT"
+        }
+      },
+      {
+        "targetChange": {
+          "targetChangeType": "ADD",
+          "targetIds": [
+            1
+          ],
+          "readTime": "1970-01-01T00:00:02Z"
+        }
+      },
+      {
+        "targetChange": {
+          "readTime": "1970-01-01T00:00:01Z"
+        }
+      }
+    ],
+    "snapshots": [
+      {
+        "docs": [
+          {
+            "name": "projects/projectID/databases/(default)/documents/C/d1",
+            "fields": {
+              "a": {
+                "integerValue": "3"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          }
+        ],
+        "changes": [
+          {
+            "kind": "ADDED",
+            "doc": {
+              "name": "projects/projectID/databases/(default)/documents/C/d1",
+              "fields": {
+                "a": {
+                  "integerValue": "3"
+                }
+              },
+              "createTime": "1970-01-01T00:00:01Z",
+              "updateTime": "1970-01-01T00:00:01Z"
+            },
+            "oldIndex": -1
+          }
+        ],
+        "readTime": "1970-01-01T00:00:01Z"
+      }
+    ]
+  }
+}

--- a/firestore/v1/testcase/listen-target-add-nop.json
+++ b/firestore/v1/testcase/listen-target-add-nop.json
@@ -1,77 +1,81 @@
 {
-  "description": "listen: TargetChange_ADD is a no-op if it has the same target ID",
-  "comment": "A TargetChange_ADD response must have the same watch target ID.",
-  "listen": {
-    "responses": [
-      {
-        "documentChange": {
-          "document": {
-            "name": "projects/projectID/databases/(default)/documents/C/d1",
-            "fields": {
-              "a": {
-                "integerValue": "3"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          },
-          "targetIds": [
-            1
-          ]
-        }
-      },
-      {
-        "targetChange": {
-          "targetChangeType": "CURRENT"
-        }
-      },
-      {
-        "targetChange": {
-          "targetChangeType": "ADD",
-          "targetIds": [
-            1
-          ],
-          "readTime": "1970-01-01T00:00:02Z"
-        }
-      },
-      {
-        "targetChange": {
-          "readTime": "1970-01-01T00:00:01Z"
-        }
-      }
-    ],
-    "snapshots": [
-      {
-        "docs": [
+  "tests": [
+    {
+      "description": "listen: TargetChange_ADD is a no-op if it has the same target ID",
+      "comment": "A TargetChange_ADD response must have the same watch target ID.",
+      "listen": {
+        "responses": [
           {
-            "name": "projects/projectID/databases/(default)/documents/C/d1",
-            "fields": {
-              "a": {
-                "integerValue": "3"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
-          }
-        ],
-        "changes": [
-          {
-            "kind": "ADDED",
-            "doc": {
-              "name": "projects/projectID/databases/(default)/documents/C/d1",
-              "fields": {
-                "a": {
-                  "integerValue": "3"
-                }
+            "documentChange": {
+              "document": {
+                "name": "projects/projectID/databases/(default)/documents/C/d1",
+                "fields": {
+                  "a": {
+                    "integerValue": "3"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
               },
-              "createTime": "1970-01-01T00:00:01Z",
-              "updateTime": "1970-01-01T00:00:01Z"
-            },
-            "oldIndex": -1
+              "targetIds": [
+                1
+              ]
+            }
+          },
+          {
+            "targetChange": {
+              "targetChangeType": "CURRENT"
+            }
+          },
+          {
+            "targetChange": {
+              "targetChangeType": "ADD",
+              "targetIds": [
+                1
+              ],
+              "readTime": "1970-01-01T00:00:02Z"
+            }
+          },
+          {
+            "targetChange": {
+              "readTime": "1970-01-01T00:00:01Z"
+            }
           }
         ],
-        "readTime": "1970-01-01T00:00:01Z"
+        "snapshots": [
+          {
+            "docs": [
+              {
+                "name": "projects/projectID/databases/(default)/documents/C/d1",
+                "fields": {
+                  "a": {
+                    "integerValue": "3"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
+              }
+            ],
+            "changes": [
+              {
+                "kind": "ADDED",
+                "doc": {
+                  "name": "projects/projectID/databases/(default)/documents/C/d1",
+                  "fields": {
+                    "a": {
+                      "integerValue": "3"
+                    }
+                  },
+                  "createTime": "1970-01-01T00:00:01Z",
+                  "updateTime": "1970-01-01T00:00:01Z"
+                },
+                "oldIndex": -1
+              }
+            ],
+            "readTime": "1970-01-01T00:00:01Z"
+          }
+        ]
       }
-    ]
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/listen-target-add-wrong-id.json
+++ b/firestore/v1/testcase/listen-target-add-wrong-id.json
@@ -1,0 +1,45 @@
+{
+  "description": "listen: TargetChange_ADD is an error if it has a different target ID",
+  "comment": "A TargetChange_ADD response must have the same watch target ID.",
+  "listen": {
+    "responses": [
+      {
+        "documentChange": {
+          "document": {
+            "name": "projects/projectID/databases/(default)/documents/C/d1",
+            "fields": {
+              "a": {
+                "integerValue": "3"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          },
+          "targetIds": [
+            1
+          ]
+        }
+      },
+      {
+        "targetChange": {
+          "targetChangeType": "CURRENT"
+        }
+      },
+      {
+        "targetChange": {
+          "targetChangeType": "ADD",
+          "targetIds": [
+            2
+          ],
+          "readTime": "1970-01-01T00:00:02Z"
+        }
+      },
+      {
+        "targetChange": {
+          "readTime": "1970-01-01T00:00:01Z"
+        }
+      }
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/listen-target-add-wrong-id.json
+++ b/firestore/v1/testcase/listen-target-add-wrong-id.json
@@ -1,45 +1,49 @@
 {
-  "description": "listen: TargetChange_ADD is an error if it has a different target ID",
-  "comment": "A TargetChange_ADD response must have the same watch target ID.",
-  "listen": {
-    "responses": [
-      {
-        "documentChange": {
-          "document": {
-            "name": "projects/projectID/databases/(default)/documents/C/d1",
-            "fields": {
-              "a": {
-                "integerValue": "3"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
+  "tests": [
+    {
+      "description": "listen: TargetChange_ADD is an error if it has a different target ID",
+      "comment": "A TargetChange_ADD response must have the same watch target ID.",
+      "listen": {
+        "responses": [
+          {
+            "documentChange": {
+              "document": {
+                "name": "projects/projectID/databases/(default)/documents/C/d1",
+                "fields": {
+                  "a": {
+                    "integerValue": "3"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
+              },
+              "targetIds": [
+                1
+              ]
+            }
           },
-          "targetIds": [
-            1
-          ]
-        }
-      },
-      {
-        "targetChange": {
-          "targetChangeType": "CURRENT"
-        }
-      },
-      {
-        "targetChange": {
-          "targetChangeType": "ADD",
-          "targetIds": [
-            2
-          ],
-          "readTime": "1970-01-01T00:00:02Z"
-        }
-      },
-      {
-        "targetChange": {
-          "readTime": "1970-01-01T00:00:01Z"
-        }
+          {
+            "targetChange": {
+              "targetChangeType": "CURRENT"
+            }
+          },
+          {
+            "targetChange": {
+              "targetChangeType": "ADD",
+              "targetIds": [
+                2
+              ],
+              "readTime": "1970-01-01T00:00:02Z"
+            }
+          },
+          {
+            "targetChange": {
+              "readTime": "1970-01-01T00:00:01Z"
+            }
+          }
+        ],
+        "isError": true
       }
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/listen-target-remove.json
+++ b/firestore/v1/testcase/listen-target-remove.json
@@ -1,0 +1,41 @@
+{
+  "description": "listen: TargetChange_REMOVE should not appear",
+  "comment": "A TargetChange_REMOVE response should never be sent.",
+  "listen": {
+    "responses": [
+      {
+        "documentChange": {
+          "document": {
+            "name": "projects/projectID/databases/(default)/documents/C/d1",
+            "fields": {
+              "a": {
+                "integerValue": "3"
+              }
+            },
+            "createTime": "1970-01-01T00:00:01Z",
+            "updateTime": "1970-01-01T00:00:01Z"
+          },
+          "targetIds": [
+            1
+          ]
+        }
+      },
+      {
+        "targetChange": {
+          "targetChangeType": "CURRENT"
+        }
+      },
+      {
+        "targetChange": {
+          "targetChangeType": "REMOVE"
+        }
+      },
+      {
+        "targetChange": {
+          "readTime": "1970-01-01T00:00:01Z"
+        }
+      }
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/listen-target-remove.json
+++ b/firestore/v1/testcase/listen-target-remove.json
@@ -1,41 +1,45 @@
 {
-  "description": "listen: TargetChange_REMOVE should not appear",
-  "comment": "A TargetChange_REMOVE response should never be sent.",
-  "listen": {
-    "responses": [
-      {
-        "documentChange": {
-          "document": {
-            "name": "projects/projectID/databases/(default)/documents/C/d1",
-            "fields": {
-              "a": {
-                "integerValue": "3"
-              }
-            },
-            "createTime": "1970-01-01T00:00:01Z",
-            "updateTime": "1970-01-01T00:00:01Z"
+  "tests": [
+    {
+      "description": "listen: TargetChange_REMOVE should not appear",
+      "comment": "A TargetChange_REMOVE response should never be sent.",
+      "listen": {
+        "responses": [
+          {
+            "documentChange": {
+              "document": {
+                "name": "projects/projectID/databases/(default)/documents/C/d1",
+                "fields": {
+                  "a": {
+                    "integerValue": "3"
+                  }
+                },
+                "createTime": "1970-01-01T00:00:01Z",
+                "updateTime": "1970-01-01T00:00:01Z"
+              },
+              "targetIds": [
+                1
+              ]
+            }
           },
-          "targetIds": [
-            1
-          ]
-        }
-      },
-      {
-        "targetChange": {
-          "targetChangeType": "CURRENT"
-        }
-      },
-      {
-        "targetChange": {
-          "targetChangeType": "REMOVE"
-        }
-      },
-      {
-        "targetChange": {
-          "readTime": "1970-01-01T00:00:01Z"
-        }
+          {
+            "targetChange": {
+              "targetChangeType": "CURRENT"
+            }
+          },
+          {
+            "targetChange": {
+              "targetChangeType": "REMOVE"
+            }
+          },
+          {
+            "targetChange": {
+              "readTime": "1970-01-01T00:00:01Z"
+            }
+          }
+        ],
+        "isError": true
       }
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/query-arrayremove-cursor.json
+++ b/firestore/v1/testcase/query-arrayremove-cursor.json
@@ -1,0 +1,27 @@
+{
+  "description": "query: ArrayRemove in cursor method",
+  "comment": "ArrayRemove is not permitted in queries.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "orderBy": {
+          "path": {
+            "field": [
+              "a"
+            ]
+          },
+          "direction": "asc"
+        }
+      },
+      {
+        "endBefore": {
+          "jsonValues": [
+            "[\"ArrayRemove\", 1, 2, 3]"
+          ]
+        }
+      }
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/query-arrayremove-cursor.json
+++ b/firestore/v1/testcase/query-arrayremove-cursor.json
@@ -1,27 +1,31 @@
 {
-  "description": "query: ArrayRemove in cursor method",
-  "comment": "ArrayRemove is not permitted in queries.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "orderBy": {
-          "path": {
-            "field": [
-              "a"
-            ]
+  "tests": [
+    {
+      "description": "query: ArrayRemove in cursor method",
+      "comment": "ArrayRemove is not permitted in queries.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
+          {
+            "orderBy": {
+              "path": {
+                "field": [
+                  "a"
+                ]
+              },
+              "direction": "asc"
+            }
           },
-          "direction": "asc"
-        }
-      },
-      {
-        "endBefore": {
-          "jsonValues": [
-            "[\"ArrayRemove\", 1, 2, 3]"
-          ]
-        }
+          {
+            "endBefore": {
+              "jsonValues": [
+                "[\"ArrayRemove\", 1, 2, 3]"
+              ]
+            }
+          }
+        ],
+        "isError": true
       }
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/query-arrayremove-where.json
+++ b/firestore/v1/testcase/query-arrayremove-where.json
@@ -1,0 +1,21 @@
+{
+  "description": "query: ArrayRemove in Where",
+  "comment": "ArrayRemove is not permitted in queries.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "where": {
+          "path": {
+            "field": [
+              "a"
+            ]
+          },
+          "op": "==",
+          "jsonValue": "[\"ArrayRemove\", 1, 2, 3]"
+        }
+      }
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/query-arrayremove-where.json
+++ b/firestore/v1/testcase/query-arrayremove-where.json
@@ -1,21 +1,25 @@
 {
-  "description": "query: ArrayRemove in Where",
-  "comment": "ArrayRemove is not permitted in queries.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "where": {
-          "path": {
-            "field": [
-              "a"
-            ]
-          },
-          "op": "==",
-          "jsonValue": "[\"ArrayRemove\", 1, 2, 3]"
-        }
+  "tests": [
+    {
+      "description": "query: ArrayRemove in Where",
+      "comment": "ArrayRemove is not permitted in queries.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
+          {
+            "where": {
+              "path": {
+                "field": [
+                  "a"
+                ]
+              },
+              "op": "==",
+              "jsonValue": "[\"ArrayRemove\", 1, 2, 3]"
+            }
+          }
+        ],
+        "isError": true
       }
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/query-arrayunion-cursor.json
+++ b/firestore/v1/testcase/query-arrayunion-cursor.json
@@ -1,0 +1,27 @@
+{
+  "description": "query: ArrayUnion in cursor method",
+  "comment": "ArrayUnion is not permitted in queries.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "orderBy": {
+          "path": {
+            "field": [
+              "a"
+            ]
+          },
+          "direction": "asc"
+        }
+      },
+      {
+        "endBefore": {
+          "jsonValues": [
+            "[\"ArrayUnion\", 1, 2, 3]"
+          ]
+        }
+      }
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/query-arrayunion-cursor.json
+++ b/firestore/v1/testcase/query-arrayunion-cursor.json
@@ -1,27 +1,31 @@
 {
-  "description": "query: ArrayUnion in cursor method",
-  "comment": "ArrayUnion is not permitted in queries.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "orderBy": {
-          "path": {
-            "field": [
-              "a"
-            ]
+  "tests": [
+    {
+      "description": "query: ArrayUnion in cursor method",
+      "comment": "ArrayUnion is not permitted in queries.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
+          {
+            "orderBy": {
+              "path": {
+                "field": [
+                  "a"
+                ]
+              },
+              "direction": "asc"
+            }
           },
-          "direction": "asc"
-        }
-      },
-      {
-        "endBefore": {
-          "jsonValues": [
-            "[\"ArrayUnion\", 1, 2, 3]"
-          ]
-        }
+          {
+            "endBefore": {
+              "jsonValues": [
+                "[\"ArrayUnion\", 1, 2, 3]"
+              ]
+            }
+          }
+        ],
+        "isError": true
       }
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/query-arrayunion-where.json
+++ b/firestore/v1/testcase/query-arrayunion-where.json
@@ -1,0 +1,21 @@
+{
+  "description": "query: ArrayUnion in Where",
+  "comment": "ArrayUnion is not permitted in queries.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "where": {
+          "path": {
+            "field": [
+              "a"
+            ]
+          },
+          "op": "==",
+          "jsonValue": "[\"ArrayUnion\", 1, 2, 3]"
+        }
+      }
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/query-arrayunion-where.json
+++ b/firestore/v1/testcase/query-arrayunion-where.json
@@ -1,21 +1,25 @@
 {
-  "description": "query: ArrayUnion in Where",
-  "comment": "ArrayUnion is not permitted in queries.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "where": {
-          "path": {
-            "field": [
-              "a"
-            ]
-          },
-          "op": "==",
-          "jsonValue": "[\"ArrayUnion\", 1, 2, 3]"
-        }
+  "tests": [
+    {
+      "description": "query: ArrayUnion in Where",
+      "comment": "ArrayUnion is not permitted in queries.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
+          {
+            "where": {
+              "path": {
+                "field": [
+                  "a"
+                ]
+              },
+              "op": "==",
+              "jsonValue": "[\"ArrayUnion\", 1, 2, 3]"
+            }
+          }
+        ],
+        "isError": true
       }
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/query-bad-NaN.json
+++ b/firestore/v1/testcase/query-bad-NaN.json
@@ -1,0 +1,21 @@
+{
+  "description": "query: where clause with non-== comparison with NaN",
+  "comment": "You can only compare NaN for equality.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "where": {
+          "path": {
+            "field": [
+              "a"
+            ]
+          },
+          "op": "\u003c",
+          "jsonValue": "\"NaN\""
+        }
+      }
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/query-bad-NaN.json
+++ b/firestore/v1/testcase/query-bad-NaN.json
@@ -1,21 +1,25 @@
 {
-  "description": "query: where clause with non-== comparison with NaN",
-  "comment": "You can only compare NaN for equality.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "where": {
-          "path": {
-            "field": [
-              "a"
-            ]
-          },
-          "op": "\u003c",
-          "jsonValue": "\"NaN\""
-        }
+  "tests": [
+    {
+      "description": "query: where clause with non-== comparison with NaN",
+      "comment": "You can only compare NaN for equality.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
+          {
+            "where": {
+              "path": {
+                "field": [
+                  "a"
+                ]
+              },
+              "op": "\u003c",
+              "jsonValue": "\"NaN\""
+            }
+          }
+        ],
+        "isError": true
       }
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/query-bad-null.json
+++ b/firestore/v1/testcase/query-bad-null.json
@@ -1,0 +1,21 @@
+{
+  "description": "query: where clause with non-== comparison with Null",
+  "comment": "You can only compare Null for equality.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "where": {
+          "path": {
+            "field": [
+              "a"
+            ]
+          },
+          "op": "\u003e",
+          "jsonValue": "null"
+        }
+      }
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/query-bad-null.json
+++ b/firestore/v1/testcase/query-bad-null.json
@@ -1,21 +1,25 @@
 {
-  "description": "query: where clause with non-== comparison with Null",
-  "comment": "You can only compare Null for equality.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "where": {
-          "path": {
-            "field": [
-              "a"
-            ]
-          },
-          "op": "\u003e",
-          "jsonValue": "null"
-        }
+  "tests": [
+    {
+      "description": "query: where clause with non-== comparison with Null",
+      "comment": "You can only compare Null for equality.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
+          {
+            "where": {
+              "path": {
+                "field": [
+                  "a"
+                ]
+              },
+              "op": "\u003e",
+              "jsonValue": "null"
+            }
+          }
+        ],
+        "isError": true
       }
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/query-cursor-docsnap-order.json
+++ b/firestore/v1/testcase/query-cursor-docsnap-order.json
@@ -1,0 +1,77 @@
+{
+  "description": "query: cursor methods with a document snapshot, existing orderBy",
+  "comment": "When a document snapshot is used, the client appends a __name__ order-by clause\nwith the direction of the last order-by clause.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "orderBy": {
+          "path": {
+            "field": [
+              "a"
+            ]
+          },
+          "direction": "asc"
+        }
+      },
+      {
+        "orderBy": {
+          "path": {
+            "field": [
+              "b"
+            ]
+          },
+          "direction": "desc"
+        }
+      },
+      {
+        "startAfter": {
+          "docSnapshot": {
+            "path": "projects/projectID/databases/(default)/documents/C/D",
+            "jsonData": "{\"a\": 7, \"b\": 8}"
+          }
+        }
+      }
+    ],
+    "query": {
+      "from": [
+        {
+          "collectionId": "C"
+        }
+      ],
+      "orderBy": [
+        {
+          "field": {
+            "fieldPath": "a"
+          },
+          "direction": "ASCENDING"
+        },
+        {
+          "field": {
+            "fieldPath": "b"
+          },
+          "direction": "DESCENDING"
+        },
+        {
+          "field": {
+            "fieldPath": "__name__"
+          },
+          "direction": "DESCENDING"
+        }
+      ],
+      "startAt": {
+        "values": [
+          {
+            "integerValue": "7"
+          },
+          {
+            "integerValue": "8"
+          },
+          {
+            "referenceValue": "projects/projectID/databases/(default)/documents/C/D"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/firestore/v1/testcase/query-cursor-docsnap-order.json
+++ b/firestore/v1/testcase/query-cursor-docsnap-order.json
@@ -1,77 +1,81 @@
 {
-  "description": "query: cursor methods with a document snapshot, existing orderBy",
-  "comment": "When a document snapshot is used, the client appends a __name__ order-by clause\nwith the direction of the last order-by clause.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "orderBy": {
-          "path": {
-            "field": [
-              "a"
-            ]
+  "tests": [
+    {
+      "description": "query: cursor methods with a document snapshot, existing orderBy",
+      "comment": "When a document snapshot is used, the client appends a __name__ order-by clause\nwith the direction of the last order-by clause.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
+          {
+            "orderBy": {
+              "path": {
+                "field": [
+                  "a"
+                ]
+              },
+              "direction": "asc"
+            }
           },
-          "direction": "asc"
-        }
-      },
-      {
-        "orderBy": {
-          "path": {
-            "field": [
-              "b"
-            ]
+          {
+            "orderBy": {
+              "path": {
+                "field": [
+                  "b"
+                ]
+              },
+              "direction": "desc"
+            }
           },
-          "direction": "desc"
-        }
-      },
-      {
-        "startAfter": {
-          "docSnapshot": {
-            "path": "projects/projectID/databases/(default)/documents/C/D",
-            "jsonData": "{\"a\": 7, \"b\": 8}"
+          {
+            "startAfter": {
+              "docSnapshot": {
+                "path": "projects/projectID/databases/(default)/documents/C/D",
+                "jsonData": "{\"a\": 7, \"b\": 8}"
+              }
+            }
+          }
+        ],
+        "query": {
+          "from": [
+            {
+              "collectionId": "C"
+            }
+          ],
+          "orderBy": [
+            {
+              "field": {
+                "fieldPath": "a"
+              },
+              "direction": "ASCENDING"
+            },
+            {
+              "field": {
+                "fieldPath": "b"
+              },
+              "direction": "DESCENDING"
+            },
+            {
+              "field": {
+                "fieldPath": "__name__"
+              },
+              "direction": "DESCENDING"
+            }
+          ],
+          "startAt": {
+            "values": [
+              {
+                "integerValue": "7"
+              },
+              {
+                "integerValue": "8"
+              },
+              {
+                "referenceValue": "projects/projectID/databases/(default)/documents/C/D"
+              }
+            ]
           }
         }
-      }
-    ],
-    "query": {
-      "from": [
-        {
-          "collectionId": "C"
-        }
-      ],
-      "orderBy": [
-        {
-          "field": {
-            "fieldPath": "a"
-          },
-          "direction": "ASCENDING"
-        },
-        {
-          "field": {
-            "fieldPath": "b"
-          },
-          "direction": "DESCENDING"
-        },
-        {
-          "field": {
-            "fieldPath": "__name__"
-          },
-          "direction": "DESCENDING"
-        }
-      ],
-      "startAt": {
-        "values": [
-          {
-            "integerValue": "7"
-          },
-          {
-            "integerValue": "8"
-          },
-          {
-            "referenceValue": "projects/projectID/databases/(default)/documents/C/D"
-          }
-        ]
       }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/query-cursor-docsnap-orderby-name.json
+++ b/firestore/v1/testcase/query-cursor-docsnap-orderby-name.json
@@ -1,0 +1,87 @@
+{
+  "description": "query: cursor method, doc snapshot, existing orderBy __name__",
+  "comment": "If there is an existing orderBy clause on __name__,\nno changes are made to the list of orderBy clauses.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "orderBy": {
+          "path": {
+            "field": [
+              "a"
+            ]
+          },
+          "direction": "desc"
+        }
+      },
+      {
+        "orderBy": {
+          "path": {
+            "field": [
+              "__name__"
+            ]
+          },
+          "direction": "asc"
+        }
+      },
+      {
+        "startAt": {
+          "docSnapshot": {
+            "path": "projects/projectID/databases/(default)/documents/C/D",
+            "jsonData": "{\"a\": 7, \"b\": 8}"
+          }
+        }
+      },
+      {
+        "endAt": {
+          "docSnapshot": {
+            "path": "projects/projectID/databases/(default)/documents/C/D",
+            "jsonData": "{\"a\": 7, \"b\": 8}"
+          }
+        }
+      }
+    ],
+    "query": {
+      "from": [
+        {
+          "collectionId": "C"
+        }
+      ],
+      "orderBy": [
+        {
+          "field": {
+            "fieldPath": "a"
+          },
+          "direction": "DESCENDING"
+        },
+        {
+          "field": {
+            "fieldPath": "__name__"
+          },
+          "direction": "ASCENDING"
+        }
+      ],
+      "startAt": {
+        "values": [
+          {
+            "integerValue": "7"
+          },
+          {
+            "referenceValue": "projects/projectID/databases/(default)/documents/C/D"
+          }
+        ],
+        "before": true
+      },
+      "endAt": {
+        "values": [
+          {
+            "integerValue": "7"
+          },
+          {
+            "referenceValue": "projects/projectID/databases/(default)/documents/C/D"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/firestore/v1/testcase/query-cursor-docsnap-orderby-name.json
+++ b/firestore/v1/testcase/query-cursor-docsnap-orderby-name.json
@@ -1,87 +1,91 @@
 {
-  "description": "query: cursor method, doc snapshot, existing orderBy __name__",
-  "comment": "If there is an existing orderBy clause on __name__,\nno changes are made to the list of orderBy clauses.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "orderBy": {
-          "path": {
-            "field": [
-              "a"
-            ]
-          },
-          "direction": "desc"
-        }
-      },
-      {
-        "orderBy": {
-          "path": {
-            "field": [
-              "__name__"
-            ]
-          },
-          "direction": "asc"
-        }
-      },
-      {
-        "startAt": {
-          "docSnapshot": {
-            "path": "projects/projectID/databases/(default)/documents/C/D",
-            "jsonData": "{\"a\": 7, \"b\": 8}"
-          }
-        }
-      },
-      {
-        "endAt": {
-          "docSnapshot": {
-            "path": "projects/projectID/databases/(default)/documents/C/D",
-            "jsonData": "{\"a\": 7, \"b\": 8}"
-          }
-        }
-      }
-    ],
-    "query": {
-      "from": [
-        {
-          "collectionId": "C"
-        }
-      ],
-      "orderBy": [
-        {
-          "field": {
-            "fieldPath": "a"
-          },
-          "direction": "DESCENDING"
-        },
-        {
-          "field": {
-            "fieldPath": "__name__"
-          },
-          "direction": "ASCENDING"
-        }
-      ],
-      "startAt": {
-        "values": [
+  "tests": [
+    {
+      "description": "query: cursor method, doc snapshot, existing orderBy __name__",
+      "comment": "If there is an existing orderBy clause on __name__,\nno changes are made to the list of orderBy clauses.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
           {
-            "integerValue": "7"
+            "orderBy": {
+              "path": {
+                "field": [
+                  "a"
+                ]
+              },
+              "direction": "desc"
+            }
           },
           {
-            "referenceValue": "projects/projectID/databases/(default)/documents/C/D"
+            "orderBy": {
+              "path": {
+                "field": [
+                  "__name__"
+                ]
+              },
+              "direction": "asc"
+            }
+          },
+          {
+            "startAt": {
+              "docSnapshot": {
+                "path": "projects/projectID/databases/(default)/documents/C/D",
+                "jsonData": "{\"a\": 7, \"b\": 8}"
+              }
+            }
+          },
+          {
+            "endAt": {
+              "docSnapshot": {
+                "path": "projects/projectID/databases/(default)/documents/C/D",
+                "jsonData": "{\"a\": 7, \"b\": 8}"
+              }
+            }
           }
         ],
-        "before": true
-      },
-      "endAt": {
-        "values": [
-          {
-            "integerValue": "7"
+        "query": {
+          "from": [
+            {
+              "collectionId": "C"
+            }
+          ],
+          "orderBy": [
+            {
+              "field": {
+                "fieldPath": "a"
+              },
+              "direction": "DESCENDING"
+            },
+            {
+              "field": {
+                "fieldPath": "__name__"
+              },
+              "direction": "ASCENDING"
+            }
+          ],
+          "startAt": {
+            "values": [
+              {
+                "integerValue": "7"
+              },
+              {
+                "referenceValue": "projects/projectID/databases/(default)/documents/C/D"
+              }
+            ],
+            "before": true
           },
-          {
-            "referenceValue": "projects/projectID/databases/(default)/documents/C/D"
+          "endAt": {
+            "values": [
+              {
+                "integerValue": "7"
+              },
+              {
+                "referenceValue": "projects/projectID/databases/(default)/documents/C/D"
+              }
+            ]
           }
-        ]
+        }
       }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/query-cursor-docsnap-where-eq.json
+++ b/firestore/v1/testcase/query-cursor-docsnap-where-eq.json
@@ -1,0 +1,61 @@
+{
+  "description": "query: cursor methods with a document snapshot and an equality where clause",
+  "comment": "A Where clause using equality doesn't change the implicit orderBy clauses.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "where": {
+          "path": {
+            "field": [
+              "a"
+            ]
+          },
+          "op": "==",
+          "jsonValue": "3"
+        }
+      },
+      {
+        "endAt": {
+          "docSnapshot": {
+            "path": "projects/projectID/databases/(default)/documents/C/D",
+            "jsonData": "{\"a\": 7, \"b\": 8}"
+          }
+        }
+      }
+    ],
+    "query": {
+      "from": [
+        {
+          "collectionId": "C"
+        }
+      ],
+      "where": {
+        "fieldFilter": {
+          "field": {
+            "fieldPath": "a"
+          },
+          "op": "EQUAL",
+          "value": {
+            "integerValue": "3"
+          }
+        }
+      },
+      "orderBy": [
+        {
+          "field": {
+            "fieldPath": "__name__"
+          },
+          "direction": "ASCENDING"
+        }
+      ],
+      "endAt": {
+        "values": [
+          {
+            "referenceValue": "projects/projectID/databases/(default)/documents/C/D"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/firestore/v1/testcase/query-cursor-docsnap-where-eq.json
+++ b/firestore/v1/testcase/query-cursor-docsnap-where-eq.json
@@ -1,61 +1,65 @@
 {
-  "description": "query: cursor methods with a document snapshot and an equality where clause",
-  "comment": "A Where clause using equality doesn't change the implicit orderBy clauses.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "where": {
-          "path": {
-            "field": [
-              "a"
-            ]
-          },
-          "op": "==",
-          "jsonValue": "3"
-        }
-      },
-      {
-        "endAt": {
-          "docSnapshot": {
-            "path": "projects/projectID/databases/(default)/documents/C/D",
-            "jsonData": "{\"a\": 7, \"b\": 8}"
-          }
-        }
-      }
-    ],
-    "query": {
-      "from": [
-        {
-          "collectionId": "C"
-        }
-      ],
-      "where": {
-        "fieldFilter": {
-          "field": {
-            "fieldPath": "a"
-          },
-          "op": "EQUAL",
-          "value": {
-            "integerValue": "3"
-          }
-        }
-      },
-      "orderBy": [
-        {
-          "field": {
-            "fieldPath": "__name__"
-          },
-          "direction": "ASCENDING"
-        }
-      ],
-      "endAt": {
-        "values": [
+  "tests": [
+    {
+      "description": "query: cursor methods with a document snapshot and an equality where clause",
+      "comment": "A Where clause using equality doesn't change the implicit orderBy clauses.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
           {
-            "referenceValue": "projects/projectID/databases/(default)/documents/C/D"
+            "where": {
+              "path": {
+                "field": [
+                  "a"
+                ]
+              },
+              "op": "==",
+              "jsonValue": "3"
+            }
+          },
+          {
+            "endAt": {
+              "docSnapshot": {
+                "path": "projects/projectID/databases/(default)/documents/C/D",
+                "jsonData": "{\"a\": 7, \"b\": 8}"
+              }
+            }
           }
-        ]
+        ],
+        "query": {
+          "from": [
+            {
+              "collectionId": "C"
+            }
+          ],
+          "where": {
+            "fieldFilter": {
+              "field": {
+                "fieldPath": "a"
+              },
+              "op": "EQUAL",
+              "value": {
+                "integerValue": "3"
+              }
+            }
+          },
+          "orderBy": [
+            {
+              "field": {
+                "fieldPath": "__name__"
+              },
+              "direction": "ASCENDING"
+            }
+          ],
+          "endAt": {
+            "values": [
+              {
+                "referenceValue": "projects/projectID/databases/(default)/documents/C/D"
+              }
+            ]
+          }
+        }
       }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/query-cursor-docsnap-where-neq-orderby.json
+++ b/firestore/v1/testcase/query-cursor-docsnap-where-neq-orderby.json
@@ -1,0 +1,81 @@
+{
+  "description": "query: cursor method, doc snapshot, inequality where clause, and existing orderBy clause",
+  "comment": "If there is an OrderBy clause, the inequality Where clause does\nnot result in a new OrderBy clause. We still add a __name__ OrderBy clause",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "orderBy": {
+          "path": {
+            "field": [
+              "a"
+            ]
+          },
+          "direction": "desc"
+        }
+      },
+      {
+        "where": {
+          "path": {
+            "field": [
+              "a"
+            ]
+          },
+          "op": "\u003c",
+          "jsonValue": "4"
+        }
+      },
+      {
+        "startAt": {
+          "docSnapshot": {
+            "path": "projects/projectID/databases/(default)/documents/C/D",
+            "jsonData": "{\"a\": 7, \"b\": 8}"
+          }
+        }
+      }
+    ],
+    "query": {
+      "from": [
+        {
+          "collectionId": "C"
+        }
+      ],
+      "where": {
+        "fieldFilter": {
+          "field": {
+            "fieldPath": "a"
+          },
+          "op": "LESS_THAN",
+          "value": {
+            "integerValue": "4"
+          }
+        }
+      },
+      "orderBy": [
+        {
+          "field": {
+            "fieldPath": "a"
+          },
+          "direction": "DESCENDING"
+        },
+        {
+          "field": {
+            "fieldPath": "__name__"
+          },
+          "direction": "DESCENDING"
+        }
+      ],
+      "startAt": {
+        "values": [
+          {
+            "integerValue": "7"
+          },
+          {
+            "referenceValue": "projects/projectID/databases/(default)/documents/C/D"
+          }
+        ],
+        "before": true
+      }
+    }
+  }
+}

--- a/firestore/v1/testcase/query-cursor-docsnap-where-neq-orderby.json
+++ b/firestore/v1/testcase/query-cursor-docsnap-where-neq-orderby.json
@@ -1,81 +1,85 @@
 {
-  "description": "query: cursor method, doc snapshot, inequality where clause, and existing orderBy clause",
-  "comment": "If there is an OrderBy clause, the inequality Where clause does\nnot result in a new OrderBy clause. We still add a __name__ OrderBy clause",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "orderBy": {
-          "path": {
-            "field": [
-              "a"
-            ]
-          },
-          "direction": "desc"
-        }
-      },
-      {
-        "where": {
-          "path": {
-            "field": [
-              "a"
-            ]
-          },
-          "op": "\u003c",
-          "jsonValue": "4"
-        }
-      },
-      {
-        "startAt": {
-          "docSnapshot": {
-            "path": "projects/projectID/databases/(default)/documents/C/D",
-            "jsonData": "{\"a\": 7, \"b\": 8}"
-          }
-        }
-      }
-    ],
-    "query": {
-      "from": [
-        {
-          "collectionId": "C"
-        }
-      ],
-      "where": {
-        "fieldFilter": {
-          "field": {
-            "fieldPath": "a"
-          },
-          "op": "LESS_THAN",
-          "value": {
-            "integerValue": "4"
-          }
-        }
-      },
-      "orderBy": [
-        {
-          "field": {
-            "fieldPath": "a"
-          },
-          "direction": "DESCENDING"
-        },
-        {
-          "field": {
-            "fieldPath": "__name__"
-          },
-          "direction": "DESCENDING"
-        }
-      ],
-      "startAt": {
-        "values": [
+  "tests": [
+    {
+      "description": "query: cursor method, doc snapshot, inequality where clause, and existing orderBy clause",
+      "comment": "If there is an OrderBy clause, the inequality Where clause does\nnot result in a new OrderBy clause. We still add a __name__ OrderBy clause",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
           {
-            "integerValue": "7"
+            "orderBy": {
+              "path": {
+                "field": [
+                  "a"
+                ]
+              },
+              "direction": "desc"
+            }
           },
           {
-            "referenceValue": "projects/projectID/databases/(default)/documents/C/D"
+            "where": {
+              "path": {
+                "field": [
+                  "a"
+                ]
+              },
+              "op": "\u003c",
+              "jsonValue": "4"
+            }
+          },
+          {
+            "startAt": {
+              "docSnapshot": {
+                "path": "projects/projectID/databases/(default)/documents/C/D",
+                "jsonData": "{\"a\": 7, \"b\": 8}"
+              }
+            }
           }
         ],
-        "before": true
+        "query": {
+          "from": [
+            {
+              "collectionId": "C"
+            }
+          ],
+          "where": {
+            "fieldFilter": {
+              "field": {
+                "fieldPath": "a"
+              },
+              "op": "LESS_THAN",
+              "value": {
+                "integerValue": "4"
+              }
+            }
+          },
+          "orderBy": [
+            {
+              "field": {
+                "fieldPath": "a"
+              },
+              "direction": "DESCENDING"
+            },
+            {
+              "field": {
+                "fieldPath": "__name__"
+              },
+              "direction": "DESCENDING"
+            }
+          ],
+          "startAt": {
+            "values": [
+              {
+                "integerValue": "7"
+              },
+              {
+                "referenceValue": "projects/projectID/databases/(default)/documents/C/D"
+              }
+            ],
+            "before": true
+          }
+        }
       }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/query-cursor-docsnap-where-neq.json
+++ b/firestore/v1/testcase/query-cursor-docsnap-where-neq.json
@@ -1,0 +1,71 @@
+{
+  "description": "query: cursor method with a document snapshot and an inequality where clause",
+  "comment": "A Where clause with an inequality results in an OrderBy clause\non that clause's path, if there are no other OrderBy clauses.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "where": {
+          "path": {
+            "field": [
+              "a"
+            ]
+          },
+          "op": "\u003c=",
+          "jsonValue": "3"
+        }
+      },
+      {
+        "endBefore": {
+          "docSnapshot": {
+            "path": "projects/projectID/databases/(default)/documents/C/D",
+            "jsonData": "{\"a\": 7, \"b\": 8}"
+          }
+        }
+      }
+    ],
+    "query": {
+      "from": [
+        {
+          "collectionId": "C"
+        }
+      ],
+      "where": {
+        "fieldFilter": {
+          "field": {
+            "fieldPath": "a"
+          },
+          "op": "LESS_THAN_OR_EQUAL",
+          "value": {
+            "integerValue": "3"
+          }
+        }
+      },
+      "orderBy": [
+        {
+          "field": {
+            "fieldPath": "a"
+          },
+          "direction": "ASCENDING"
+        },
+        {
+          "field": {
+            "fieldPath": "__name__"
+          },
+          "direction": "ASCENDING"
+        }
+      ],
+      "endAt": {
+        "values": [
+          {
+            "integerValue": "7"
+          },
+          {
+            "referenceValue": "projects/projectID/databases/(default)/documents/C/D"
+          }
+        ],
+        "before": true
+      }
+    }
+  }
+}

--- a/firestore/v1/testcase/query-cursor-docsnap-where-neq.json
+++ b/firestore/v1/testcase/query-cursor-docsnap-where-neq.json
@@ -1,71 +1,75 @@
 {
-  "description": "query: cursor method with a document snapshot and an inequality where clause",
-  "comment": "A Where clause with an inequality results in an OrderBy clause\non that clause's path, if there are no other OrderBy clauses.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "where": {
-          "path": {
-            "field": [
-              "a"
-            ]
-          },
-          "op": "\u003c=",
-          "jsonValue": "3"
-        }
-      },
-      {
-        "endBefore": {
-          "docSnapshot": {
-            "path": "projects/projectID/databases/(default)/documents/C/D",
-            "jsonData": "{\"a\": 7, \"b\": 8}"
-          }
-        }
-      }
-    ],
-    "query": {
-      "from": [
-        {
-          "collectionId": "C"
-        }
-      ],
-      "where": {
-        "fieldFilter": {
-          "field": {
-            "fieldPath": "a"
-          },
-          "op": "LESS_THAN_OR_EQUAL",
-          "value": {
-            "integerValue": "3"
-          }
-        }
-      },
-      "orderBy": [
-        {
-          "field": {
-            "fieldPath": "a"
-          },
-          "direction": "ASCENDING"
-        },
-        {
-          "field": {
-            "fieldPath": "__name__"
-          },
-          "direction": "ASCENDING"
-        }
-      ],
-      "endAt": {
-        "values": [
+  "tests": [
+    {
+      "description": "query: cursor method with a document snapshot and an inequality where clause",
+      "comment": "A Where clause with an inequality results in an OrderBy clause\non that clause's path, if there are no other OrderBy clauses.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
           {
-            "integerValue": "7"
+            "where": {
+              "path": {
+                "field": [
+                  "a"
+                ]
+              },
+              "op": "\u003c=",
+              "jsonValue": "3"
+            }
           },
           {
-            "referenceValue": "projects/projectID/databases/(default)/documents/C/D"
+            "endBefore": {
+              "docSnapshot": {
+                "path": "projects/projectID/databases/(default)/documents/C/D",
+                "jsonData": "{\"a\": 7, \"b\": 8}"
+              }
+            }
           }
         ],
-        "before": true
+        "query": {
+          "from": [
+            {
+              "collectionId": "C"
+            }
+          ],
+          "where": {
+            "fieldFilter": {
+              "field": {
+                "fieldPath": "a"
+              },
+              "op": "LESS_THAN_OR_EQUAL",
+              "value": {
+                "integerValue": "3"
+              }
+            }
+          },
+          "orderBy": [
+            {
+              "field": {
+                "fieldPath": "a"
+              },
+              "direction": "ASCENDING"
+            },
+            {
+              "field": {
+                "fieldPath": "__name__"
+              },
+              "direction": "ASCENDING"
+            }
+          ],
+          "endAt": {
+            "values": [
+              {
+                "integerValue": "7"
+              },
+              {
+                "referenceValue": "projects/projectID/databases/(default)/documents/C/D"
+              }
+            ],
+            "before": true
+          }
+        }
       }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/query-cursor-docsnap.json
+++ b/firestore/v1/testcase/query-cursor-docsnap.json
@@ -1,0 +1,40 @@
+{
+  "description": "query: cursor methods with a document snapshot",
+  "comment": "When a document snapshot is used, the client appends a __name__ order-by clause.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "startAt": {
+          "docSnapshot": {
+            "path": "projects/projectID/databases/(default)/documents/C/D",
+            "jsonData": "{\"a\": 7, \"b\": 8}"
+          }
+        }
+      }
+    ],
+    "query": {
+      "from": [
+        {
+          "collectionId": "C"
+        }
+      ],
+      "orderBy": [
+        {
+          "field": {
+            "fieldPath": "__name__"
+          },
+          "direction": "ASCENDING"
+        }
+      ],
+      "startAt": {
+        "values": [
+          {
+            "referenceValue": "projects/projectID/databases/(default)/documents/C/D"
+          }
+        ],
+        "before": true
+      }
+    }
+  }
+}

--- a/firestore/v1/testcase/query-cursor-docsnap.json
+++ b/firestore/v1/testcase/query-cursor-docsnap.json
@@ -1,40 +1,44 @@
 {
-  "description": "query: cursor methods with a document snapshot",
-  "comment": "When a document snapshot is used, the client appends a __name__ order-by clause.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "startAt": {
-          "docSnapshot": {
-            "path": "projects/projectID/databases/(default)/documents/C/D",
-            "jsonData": "{\"a\": 7, \"b\": 8}"
-          }
-        }
-      }
-    ],
-    "query": {
-      "from": [
-        {
-          "collectionId": "C"
-        }
-      ],
-      "orderBy": [
-        {
-          "field": {
-            "fieldPath": "__name__"
-          },
-          "direction": "ASCENDING"
-        }
-      ],
-      "startAt": {
-        "values": [
+  "tests": [
+    {
+      "description": "query: cursor methods with a document snapshot",
+      "comment": "When a document snapshot is used, the client appends a __name__ order-by clause.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
           {
-            "referenceValue": "projects/projectID/databases/(default)/documents/C/D"
+            "startAt": {
+              "docSnapshot": {
+                "path": "projects/projectID/databases/(default)/documents/C/D",
+                "jsonData": "{\"a\": 7, \"b\": 8}"
+              }
+            }
           }
         ],
-        "before": true
+        "query": {
+          "from": [
+            {
+              "collectionId": "C"
+            }
+          ],
+          "orderBy": [
+            {
+              "field": {
+                "fieldPath": "__name__"
+              },
+              "direction": "ASCENDING"
+            }
+          ],
+          "startAt": {
+            "values": [
+              {
+                "referenceValue": "projects/projectID/databases/(default)/documents/C/D"
+              }
+            ],
+            "before": true
+          }
+        }
       }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/query-cursor-endbefore-empty-map.json
+++ b/firestore/v1/testcase/query-cursor-endbefore-empty-map.json
@@ -1,0 +1,51 @@
+{
+  "description": "query: EndBefore with explicit empty map",
+  "comment": "Cursor methods are allowed to use empty maps with EndBefore. It should result in an empty map in the query.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "orderBy": {
+          "path": {
+            "field": [
+              "a"
+            ]
+          },
+          "direction": "asc"
+        }
+      },
+      {
+        "endBefore": {
+          "jsonValues": [
+            "{}"
+          ]
+        }
+      }
+    ],
+    "query": {
+      "from": [
+        {
+          "collectionId": "C"
+        }
+      ],
+      "orderBy": [
+        {
+          "field": {
+            "fieldPath": "a"
+          },
+          "direction": "ASCENDING"
+        }
+      ],
+      "endAt": {
+        "values": [
+          {
+            "mapValue": {
+              "fields": {}
+            }
+          }
+        ],
+        "before": true
+      }
+    }
+  }
+}

--- a/firestore/v1/testcase/query-cursor-endbefore-empty-map.json
+++ b/firestore/v1/testcase/query-cursor-endbefore-empty-map.json
@@ -1,51 +1,55 @@
 {
-  "description": "query: EndBefore with explicit empty map",
-  "comment": "Cursor methods are allowed to use empty maps with EndBefore. It should result in an empty map in the query.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "orderBy": {
-          "path": {
-            "field": [
-              "a"
-            ]
-          },
-          "direction": "asc"
-        }
-      },
-      {
-        "endBefore": {
-          "jsonValues": [
-            "{}"
-          ]
-        }
-      }
-    ],
-    "query": {
-      "from": [
-        {
-          "collectionId": "C"
-        }
-      ],
-      "orderBy": [
-        {
-          "field": {
-            "fieldPath": "a"
-          },
-          "direction": "ASCENDING"
-        }
-      ],
-      "endAt": {
-        "values": [
+  "tests": [
+    {
+      "description": "query: EndBefore with explicit empty map",
+      "comment": "Cursor methods are allowed to use empty maps with EndBefore. It should result in an empty map in the query.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
           {
-            "mapValue": {
-              "fields": {}
+            "orderBy": {
+              "path": {
+                "field": [
+                  "a"
+                ]
+              },
+              "direction": "asc"
+            }
+          },
+          {
+            "endBefore": {
+              "jsonValues": [
+                "{}"
+              ]
             }
           }
         ],
-        "before": true
+        "query": {
+          "from": [
+            {
+              "collectionId": "C"
+            }
+          ],
+          "orderBy": [
+            {
+              "field": {
+                "fieldPath": "a"
+              },
+              "direction": "ASCENDING"
+            }
+          ],
+          "endAt": {
+            "values": [
+              {
+                "mapValue": {
+                  "fields": {}
+                }
+              }
+            ],
+            "before": true
+          }
+        }
       }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/query-cursor-endbefore-empty.json
+++ b/firestore/v1/testcase/query-cursor-endbefore-empty.json
@@ -1,0 +1,23 @@
+{
+  "description": "query: EndBefore with empty values",
+  "comment": "Cursor methods are not allowed to use empty values with EndBefore. It should result in an error.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "orderBy": {
+          "path": {
+            "field": [
+              "a"
+            ]
+          },
+          "direction": "asc"
+        }
+      },
+      {
+        "endBefore": {}
+      }
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/query-cursor-endbefore-empty.json
+++ b/firestore/v1/testcase/query-cursor-endbefore-empty.json
@@ -1,23 +1,27 @@
 {
-  "description": "query: EndBefore with empty values",
-  "comment": "Cursor methods are not allowed to use empty values with EndBefore. It should result in an error.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "orderBy": {
-          "path": {
-            "field": [
-              "a"
-            ]
+  "tests": [
+    {
+      "description": "query: EndBefore with empty values",
+      "comment": "Cursor methods are not allowed to use empty values with EndBefore. It should result in an error.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
+          {
+            "orderBy": {
+              "path": {
+                "field": [
+                  "a"
+                ]
+              },
+              "direction": "asc"
+            }
           },
-          "direction": "asc"
-        }
-      },
-      {
-        "endBefore": {}
+          {
+            "endBefore": {}
+          }
+        ],
+        "isError": true
       }
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/query-cursor-no-order.json
+++ b/firestore/v1/testcase/query-cursor-no-order.json
@@ -1,0 +1,17 @@
+{
+  "description": "query: cursor method without orderBy",
+  "comment": "If a cursor method with a list of values is provided, there must be at least as many\nexplicit orderBy clauses as values.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "startAt": {
+          "jsonValues": [
+            "2"
+          ]
+        }
+      }
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/query-cursor-no-order.json
+++ b/firestore/v1/testcase/query-cursor-no-order.json
@@ -1,17 +1,21 @@
 {
-  "description": "query: cursor method without orderBy",
-  "comment": "If a cursor method with a list of values is provided, there must be at least as many\nexplicit orderBy clauses as values.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "startAt": {
-          "jsonValues": [
-            "2"
-          ]
-        }
+  "tests": [
+    {
+      "description": "query: cursor method without orderBy",
+      "comment": "If a cursor method with a list of values is provided, there must be at least as many\nexplicit orderBy clauses as values.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
+          {
+            "startAt": {
+              "jsonValues": [
+                "2"
+              ]
+            }
+          }
+        ],
+        "isError": true
       }
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/query-cursor-startat-empty-map.json
+++ b/firestore/v1/testcase/query-cursor-startat-empty-map.json
@@ -1,0 +1,51 @@
+{
+  "description": "query: StartAt with explicit empty map",
+  "comment": "Cursor methods are allowed to use empty maps with StartAt. It should result in an empty map in the query.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "orderBy": {
+          "path": {
+            "field": [
+              "a"
+            ]
+          },
+          "direction": "asc"
+        }
+      },
+      {
+        "startAt": {
+          "jsonValues": [
+            "{}"
+          ]
+        }
+      }
+    ],
+    "query": {
+      "from": [
+        {
+          "collectionId": "C"
+        }
+      ],
+      "orderBy": [
+        {
+          "field": {
+            "fieldPath": "a"
+          },
+          "direction": "ASCENDING"
+        }
+      ],
+      "startAt": {
+        "values": [
+          {
+            "mapValue": {
+              "fields": {}
+            }
+          }
+        ],
+        "before": true
+      }
+    }
+  }
+}

--- a/firestore/v1/testcase/query-cursor-startat-empty-map.json
+++ b/firestore/v1/testcase/query-cursor-startat-empty-map.json
@@ -1,51 +1,55 @@
 {
-  "description": "query: StartAt with explicit empty map",
-  "comment": "Cursor methods are allowed to use empty maps with StartAt. It should result in an empty map in the query.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "orderBy": {
-          "path": {
-            "field": [
-              "a"
-            ]
-          },
-          "direction": "asc"
-        }
-      },
-      {
-        "startAt": {
-          "jsonValues": [
-            "{}"
-          ]
-        }
-      }
-    ],
-    "query": {
-      "from": [
-        {
-          "collectionId": "C"
-        }
-      ],
-      "orderBy": [
-        {
-          "field": {
-            "fieldPath": "a"
-          },
-          "direction": "ASCENDING"
-        }
-      ],
-      "startAt": {
-        "values": [
+  "tests": [
+    {
+      "description": "query: StartAt with explicit empty map",
+      "comment": "Cursor methods are allowed to use empty maps with StartAt. It should result in an empty map in the query.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
           {
-            "mapValue": {
-              "fields": {}
+            "orderBy": {
+              "path": {
+                "field": [
+                  "a"
+                ]
+              },
+              "direction": "asc"
+            }
+          },
+          {
+            "startAt": {
+              "jsonValues": [
+                "{}"
+              ]
             }
           }
         ],
-        "before": true
+        "query": {
+          "from": [
+            {
+              "collectionId": "C"
+            }
+          ],
+          "orderBy": [
+            {
+              "field": {
+                "fieldPath": "a"
+              },
+              "direction": "ASCENDING"
+            }
+          ],
+          "startAt": {
+            "values": [
+              {
+                "mapValue": {
+                  "fields": {}
+                }
+              }
+            ],
+            "before": true
+          }
+        }
       }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/query-cursor-startat-empty.json
+++ b/firestore/v1/testcase/query-cursor-startat-empty.json
@@ -1,0 +1,23 @@
+{
+  "description": "query: StartAt with empty values",
+  "comment": "Cursor methods are not allowed to use empty values with StartAt. It should result in an error.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "orderBy": {
+          "path": {
+            "field": [
+              "a"
+            ]
+          },
+          "direction": "asc"
+        }
+      },
+      {
+        "startAt": {}
+      }
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/query-cursor-startat-empty.json
+++ b/firestore/v1/testcase/query-cursor-startat-empty.json
@@ -1,23 +1,27 @@
 {
-  "description": "query: StartAt with empty values",
-  "comment": "Cursor methods are not allowed to use empty values with StartAt. It should result in an error.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "orderBy": {
-          "path": {
-            "field": [
-              "a"
-            ]
+  "tests": [
+    {
+      "description": "query: StartAt with empty values",
+      "comment": "Cursor methods are not allowed to use empty values with StartAt. It should result in an error.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
+          {
+            "orderBy": {
+              "path": {
+                "field": [
+                  "a"
+                ]
+              },
+              "direction": "asc"
+            }
           },
-          "direction": "asc"
-        }
-      },
-      {
-        "startAt": {}
+          {
+            "startAt": {}
+          }
+        ],
+        "isError": true
       }
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/query-cursor-vals-1a.json
+++ b/firestore/v1/testcase/query-cursor-vals-1a.json
@@ -1,0 +1,64 @@
+{
+  "description": "query: StartAt/EndBefore with values",
+  "comment": "Cursor methods take the same number of values as there are OrderBy clauses.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "orderBy": {
+          "path": {
+            "field": [
+              "a"
+            ]
+          },
+          "direction": "asc"
+        }
+      },
+      {
+        "startAt": {
+          "jsonValues": [
+            "7"
+          ]
+        }
+      },
+      {
+        "endBefore": {
+          "jsonValues": [
+            "9"
+          ]
+        }
+      }
+    ],
+    "query": {
+      "from": [
+        {
+          "collectionId": "C"
+        }
+      ],
+      "orderBy": [
+        {
+          "field": {
+            "fieldPath": "a"
+          },
+          "direction": "ASCENDING"
+        }
+      ],
+      "startAt": {
+        "values": [
+          {
+            "integerValue": "7"
+          }
+        ],
+        "before": true
+      },
+      "endAt": {
+        "values": [
+          {
+            "integerValue": "9"
+          }
+        ],
+        "before": true
+      }
+    }
+  }
+}

--- a/firestore/v1/testcase/query-cursor-vals-1a.json
+++ b/firestore/v1/testcase/query-cursor-vals-1a.json
@@ -1,64 +1,68 @@
 {
-  "description": "query: StartAt/EndBefore with values",
-  "comment": "Cursor methods take the same number of values as there are OrderBy clauses.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "orderBy": {
-          "path": {
-            "field": [
-              "a"
-            ]
-          },
-          "direction": "asc"
-        }
-      },
-      {
-        "startAt": {
-          "jsonValues": [
-            "7"
-          ]
-        }
-      },
-      {
-        "endBefore": {
-          "jsonValues": [
-            "9"
-          ]
-        }
-      }
-    ],
-    "query": {
-      "from": [
-        {
-          "collectionId": "C"
-        }
-      ],
-      "orderBy": [
-        {
-          "field": {
-            "fieldPath": "a"
-          },
-          "direction": "ASCENDING"
-        }
-      ],
-      "startAt": {
-        "values": [
+  "tests": [
+    {
+      "description": "query: StartAt/EndBefore with values",
+      "comment": "Cursor methods take the same number of values as there are OrderBy clauses.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
           {
-            "integerValue": "7"
+            "orderBy": {
+              "path": {
+                "field": [
+                  "a"
+                ]
+              },
+              "direction": "asc"
+            }
+          },
+          {
+            "startAt": {
+              "jsonValues": [
+                "7"
+              ]
+            }
+          },
+          {
+            "endBefore": {
+              "jsonValues": [
+                "9"
+              ]
+            }
           }
         ],
-        "before": true
-      },
-      "endAt": {
-        "values": [
-          {
-            "integerValue": "9"
+        "query": {
+          "from": [
+            {
+              "collectionId": "C"
+            }
+          ],
+          "orderBy": [
+            {
+              "field": {
+                "fieldPath": "a"
+              },
+              "direction": "ASCENDING"
+            }
+          ],
+          "startAt": {
+            "values": [
+              {
+                "integerValue": "7"
+              }
+            ],
+            "before": true
+          },
+          "endAt": {
+            "values": [
+              {
+                "integerValue": "9"
+              }
+            ],
+            "before": true
           }
-        ],
-        "before": true
+        }
       }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/query-cursor-vals-1b.json
+++ b/firestore/v1/testcase/query-cursor-vals-1b.json
@@ -1,0 +1,62 @@
+{
+  "description": "query: StartAfter/EndAt with values",
+  "comment": "Cursor methods take the same number of values as there are OrderBy clauses.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "orderBy": {
+          "path": {
+            "field": [
+              "a"
+            ]
+          },
+          "direction": "asc"
+        }
+      },
+      {
+        "startAfter": {
+          "jsonValues": [
+            "7"
+          ]
+        }
+      },
+      {
+        "endAt": {
+          "jsonValues": [
+            "9"
+          ]
+        }
+      }
+    ],
+    "query": {
+      "from": [
+        {
+          "collectionId": "C"
+        }
+      ],
+      "orderBy": [
+        {
+          "field": {
+            "fieldPath": "a"
+          },
+          "direction": "ASCENDING"
+        }
+      ],
+      "startAt": {
+        "values": [
+          {
+            "integerValue": "7"
+          }
+        ]
+      },
+      "endAt": {
+        "values": [
+          {
+            "integerValue": "9"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/firestore/v1/testcase/query-cursor-vals-1b.json
+++ b/firestore/v1/testcase/query-cursor-vals-1b.json
@@ -1,62 +1,66 @@
 {
-  "description": "query: StartAfter/EndAt with values",
-  "comment": "Cursor methods take the same number of values as there are OrderBy clauses.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "orderBy": {
-          "path": {
-            "field": [
-              "a"
+  "tests": [
+    {
+      "description": "query: StartAfter/EndAt with values",
+      "comment": "Cursor methods take the same number of values as there are OrderBy clauses.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
+          {
+            "orderBy": {
+              "path": {
+                "field": [
+                  "a"
+                ]
+              },
+              "direction": "asc"
+            }
+          },
+          {
+            "startAfter": {
+              "jsonValues": [
+                "7"
+              ]
+            }
+          },
+          {
+            "endAt": {
+              "jsonValues": [
+                "9"
+              ]
+            }
+          }
+        ],
+        "query": {
+          "from": [
+            {
+              "collectionId": "C"
+            }
+          ],
+          "orderBy": [
+            {
+              "field": {
+                "fieldPath": "a"
+              },
+              "direction": "ASCENDING"
+            }
+          ],
+          "startAt": {
+            "values": [
+              {
+                "integerValue": "7"
+              }
             ]
           },
-          "direction": "asc"
-        }
-      },
-      {
-        "startAfter": {
-          "jsonValues": [
-            "7"
-          ]
-        }
-      },
-      {
-        "endAt": {
-          "jsonValues": [
-            "9"
-          ]
-        }
-      }
-    ],
-    "query": {
-      "from": [
-        {
-          "collectionId": "C"
-        }
-      ],
-      "orderBy": [
-        {
-          "field": {
-            "fieldPath": "a"
-          },
-          "direction": "ASCENDING"
-        }
-      ],
-      "startAt": {
-        "values": [
-          {
-            "integerValue": "7"
+          "endAt": {
+            "values": [
+              {
+                "integerValue": "9"
+              }
+            ]
           }
-        ]
-      },
-      "endAt": {
-        "values": [
-          {
-            "integerValue": "9"
-          }
-        ]
+        }
       }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/query-cursor-vals-2.json
+++ b/firestore/v1/testcase/query-cursor-vals-2.json
@@ -1,0 +1,87 @@
+{
+  "description": "query: Start/End with two values",
+  "comment": "Cursor methods take the same number of values as there are OrderBy clauses.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "orderBy": {
+          "path": {
+            "field": [
+              "a"
+            ]
+          },
+          "direction": "asc"
+        }
+      },
+      {
+        "orderBy": {
+          "path": {
+            "field": [
+              "b"
+            ]
+          },
+          "direction": "desc"
+        }
+      },
+      {
+        "startAt": {
+          "jsonValues": [
+            "7",
+            "8"
+          ]
+        }
+      },
+      {
+        "endAt": {
+          "jsonValues": [
+            "9",
+            "10"
+          ]
+        }
+      }
+    ],
+    "query": {
+      "from": [
+        {
+          "collectionId": "C"
+        }
+      ],
+      "orderBy": [
+        {
+          "field": {
+            "fieldPath": "a"
+          },
+          "direction": "ASCENDING"
+        },
+        {
+          "field": {
+            "fieldPath": "b"
+          },
+          "direction": "DESCENDING"
+        }
+      ],
+      "startAt": {
+        "values": [
+          {
+            "integerValue": "7"
+          },
+          {
+            "integerValue": "8"
+          }
+        ],
+        "before": true
+      },
+      "endAt": {
+        "values": [
+          {
+            "integerValue": "9"
+          },
+          {
+            "integerValue": "10"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/firestore/v1/testcase/query-cursor-vals-2.json
+++ b/firestore/v1/testcase/query-cursor-vals-2.json
@@ -1,87 +1,91 @@
 {
-  "description": "query: Start/End with two values",
-  "comment": "Cursor methods take the same number of values as there are OrderBy clauses.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "orderBy": {
-          "path": {
-            "field": [
-              "a"
-            ]
-          },
-          "direction": "asc"
-        }
-      },
-      {
-        "orderBy": {
-          "path": {
-            "field": [
-              "b"
-            ]
-          },
-          "direction": "desc"
-        }
-      },
-      {
-        "startAt": {
-          "jsonValues": [
-            "7",
-            "8"
-          ]
-        }
-      },
-      {
-        "endAt": {
-          "jsonValues": [
-            "9",
-            "10"
-          ]
-        }
-      }
-    ],
-    "query": {
-      "from": [
-        {
-          "collectionId": "C"
-        }
-      ],
-      "orderBy": [
-        {
-          "field": {
-            "fieldPath": "a"
-          },
-          "direction": "ASCENDING"
-        },
-        {
-          "field": {
-            "fieldPath": "b"
-          },
-          "direction": "DESCENDING"
-        }
-      ],
-      "startAt": {
-        "values": [
+  "tests": [
+    {
+      "description": "query: Start/End with two values",
+      "comment": "Cursor methods take the same number of values as there are OrderBy clauses.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
           {
-            "integerValue": "7"
+            "orderBy": {
+              "path": {
+                "field": [
+                  "a"
+                ]
+              },
+              "direction": "asc"
+            }
           },
           {
-            "integerValue": "8"
+            "orderBy": {
+              "path": {
+                "field": [
+                  "b"
+                ]
+              },
+              "direction": "desc"
+            }
+          },
+          {
+            "startAt": {
+              "jsonValues": [
+                "7",
+                "8"
+              ]
+            }
+          },
+          {
+            "endAt": {
+              "jsonValues": [
+                "9",
+                "10"
+              ]
+            }
           }
         ],
-        "before": true
-      },
-      "endAt": {
-        "values": [
-          {
-            "integerValue": "9"
+        "query": {
+          "from": [
+            {
+              "collectionId": "C"
+            }
+          ],
+          "orderBy": [
+            {
+              "field": {
+                "fieldPath": "a"
+              },
+              "direction": "ASCENDING"
+            },
+            {
+              "field": {
+                "fieldPath": "b"
+              },
+              "direction": "DESCENDING"
+            }
+          ],
+          "startAt": {
+            "values": [
+              {
+                "integerValue": "7"
+              },
+              {
+                "integerValue": "8"
+              }
+            ],
+            "before": true
           },
-          {
-            "integerValue": "10"
+          "endAt": {
+            "values": [
+              {
+                "integerValue": "9"
+              },
+              {
+                "integerValue": "10"
+              }
+            ]
           }
-        ]
+        }
       }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/query-cursor-vals-docid.json
+++ b/firestore/v1/testcase/query-cursor-vals-docid.json
@@ -1,0 +1,63 @@
+{
+  "description": "query: cursor methods with __name__",
+  "comment": "Cursor values corresponding to a __name__ field take the document path relative to the\nquery's collection.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "orderBy": {
+          "path": {
+            "field": [
+              "__name__"
+            ]
+          },
+          "direction": "asc"
+        }
+      },
+      {
+        "startAfter": {
+          "jsonValues": [
+            "\"D1\""
+          ]
+        }
+      },
+      {
+        "endBefore": {
+          "jsonValues": [
+            "\"D2\""
+          ]
+        }
+      }
+    ],
+    "query": {
+      "from": [
+        {
+          "collectionId": "C"
+        }
+      ],
+      "orderBy": [
+        {
+          "field": {
+            "fieldPath": "__name__"
+          },
+          "direction": "ASCENDING"
+        }
+      ],
+      "startAt": {
+        "values": [
+          {
+            "referenceValue": "projects/projectID/databases/(default)/documents/C/D1"
+          }
+        ]
+      },
+      "endAt": {
+        "values": [
+          {
+            "referenceValue": "projects/projectID/databases/(default)/documents/C/D2"
+          }
+        ],
+        "before": true
+      }
+    }
+  }
+}

--- a/firestore/v1/testcase/query-cursor-vals-docid.json
+++ b/firestore/v1/testcase/query-cursor-vals-docid.json
@@ -1,63 +1,67 @@
 {
-  "description": "query: cursor methods with __name__",
-  "comment": "Cursor values corresponding to a __name__ field take the document path relative to the\nquery's collection.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "orderBy": {
-          "path": {
-            "field": [
-              "__name__"
-            ]
-          },
-          "direction": "asc"
-        }
-      },
-      {
-        "startAfter": {
-          "jsonValues": [
-            "\"D1\""
-          ]
-        }
-      },
-      {
-        "endBefore": {
-          "jsonValues": [
-            "\"D2\""
-          ]
-        }
-      }
-    ],
-    "query": {
-      "from": [
-        {
-          "collectionId": "C"
-        }
-      ],
-      "orderBy": [
-        {
-          "field": {
-            "fieldPath": "__name__"
-          },
-          "direction": "ASCENDING"
-        }
-      ],
-      "startAt": {
-        "values": [
+  "tests": [
+    {
+      "description": "query: cursor methods with __name__",
+      "comment": "Cursor values corresponding to a __name__ field take the document path relative to the\nquery's collection.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
           {
-            "referenceValue": "projects/projectID/databases/(default)/documents/C/D1"
-          }
-        ]
-      },
-      "endAt": {
-        "values": [
+            "orderBy": {
+              "path": {
+                "field": [
+                  "__name__"
+                ]
+              },
+              "direction": "asc"
+            }
+          },
           {
-            "referenceValue": "projects/projectID/databases/(default)/documents/C/D2"
+            "startAfter": {
+              "jsonValues": [
+                "\"D1\""
+              ]
+            }
+          },
+          {
+            "endBefore": {
+              "jsonValues": [
+                "\"D2\""
+              ]
+            }
           }
         ],
-        "before": true
+        "query": {
+          "from": [
+            {
+              "collectionId": "C"
+            }
+          ],
+          "orderBy": [
+            {
+              "field": {
+                "fieldPath": "__name__"
+              },
+              "direction": "ASCENDING"
+            }
+          ],
+          "startAt": {
+            "values": [
+              {
+                "referenceValue": "projects/projectID/databases/(default)/documents/C/D1"
+              }
+            ]
+          },
+          "endAt": {
+            "values": [
+              {
+                "referenceValue": "projects/projectID/databases/(default)/documents/C/D2"
+              }
+            ],
+            "before": true
+          }
+        }
       }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/query-cursor-vals-last-wins.json
+++ b/firestore/v1/testcase/query-cursor-vals-last-wins.json
@@ -1,0 +1,78 @@
+{
+  "description": "query: cursor methods, last one wins",
+  "comment": "When multiple Start* or End* calls occur, the values of the last one are used.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "orderBy": {
+          "path": {
+            "field": [
+              "a"
+            ]
+          },
+          "direction": "asc"
+        }
+      },
+      {
+        "startAfter": {
+          "jsonValues": [
+            "1"
+          ]
+        }
+      },
+      {
+        "startAt": {
+          "jsonValues": [
+            "2"
+          ]
+        }
+      },
+      {
+        "endAt": {
+          "jsonValues": [
+            "3"
+          ]
+        }
+      },
+      {
+        "endBefore": {
+          "jsonValues": [
+            "4"
+          ]
+        }
+      }
+    ],
+    "query": {
+      "from": [
+        {
+          "collectionId": "C"
+        }
+      ],
+      "orderBy": [
+        {
+          "field": {
+            "fieldPath": "a"
+          },
+          "direction": "ASCENDING"
+        }
+      ],
+      "startAt": {
+        "values": [
+          {
+            "integerValue": "2"
+          }
+        ],
+        "before": true
+      },
+      "endAt": {
+        "values": [
+          {
+            "integerValue": "4"
+          }
+        ],
+        "before": true
+      }
+    }
+  }
+}

--- a/firestore/v1/testcase/query-cursor-vals-last-wins.json
+++ b/firestore/v1/testcase/query-cursor-vals-last-wins.json
@@ -1,78 +1,82 @@
 {
-  "description": "query: cursor methods, last one wins",
-  "comment": "When multiple Start* or End* calls occur, the values of the last one are used.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "orderBy": {
-          "path": {
-            "field": [
-              "a"
-            ]
-          },
-          "direction": "asc"
-        }
-      },
-      {
-        "startAfter": {
-          "jsonValues": [
-            "1"
-          ]
-        }
-      },
-      {
-        "startAt": {
-          "jsonValues": [
-            "2"
-          ]
-        }
-      },
-      {
-        "endAt": {
-          "jsonValues": [
-            "3"
-          ]
-        }
-      },
-      {
-        "endBefore": {
-          "jsonValues": [
-            "4"
-          ]
-        }
-      }
-    ],
-    "query": {
-      "from": [
-        {
-          "collectionId": "C"
-        }
-      ],
-      "orderBy": [
-        {
-          "field": {
-            "fieldPath": "a"
-          },
-          "direction": "ASCENDING"
-        }
-      ],
-      "startAt": {
-        "values": [
+  "tests": [
+    {
+      "description": "query: cursor methods, last one wins",
+      "comment": "When multiple Start* or End* calls occur, the values of the last one are used.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
           {
-            "integerValue": "2"
+            "orderBy": {
+              "path": {
+                "field": [
+                  "a"
+                ]
+              },
+              "direction": "asc"
+            }
+          },
+          {
+            "startAfter": {
+              "jsonValues": [
+                "1"
+              ]
+            }
+          },
+          {
+            "startAt": {
+              "jsonValues": [
+                "2"
+              ]
+            }
+          },
+          {
+            "endAt": {
+              "jsonValues": [
+                "3"
+              ]
+            }
+          },
+          {
+            "endBefore": {
+              "jsonValues": [
+                "4"
+              ]
+            }
           }
         ],
-        "before": true
-      },
-      "endAt": {
-        "values": [
-          {
-            "integerValue": "4"
+        "query": {
+          "from": [
+            {
+              "collectionId": "C"
+            }
+          ],
+          "orderBy": [
+            {
+              "field": {
+                "fieldPath": "a"
+              },
+              "direction": "ASCENDING"
+            }
+          ],
+          "startAt": {
+            "values": [
+              {
+                "integerValue": "2"
+              }
+            ],
+            "before": true
+          },
+          "endAt": {
+            "values": [
+              {
+                "integerValue": "4"
+              }
+            ],
+            "before": true
           }
-        ],
-        "before": true
+        }
       }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/query-del-cursor.json
+++ b/firestore/v1/testcase/query-del-cursor.json
@@ -1,0 +1,27 @@
+{
+  "description": "query: Delete in cursor method",
+  "comment": "Sentinel values are not permitted in queries.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "orderBy": {
+          "path": {
+            "field": [
+              "a"
+            ]
+          },
+          "direction": "asc"
+        }
+      },
+      {
+        "endBefore": {
+          "jsonValues": [
+            "\"Delete\""
+          ]
+        }
+      }
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/query-del-cursor.json
+++ b/firestore/v1/testcase/query-del-cursor.json
@@ -1,27 +1,31 @@
 {
-  "description": "query: Delete in cursor method",
-  "comment": "Sentinel values are not permitted in queries.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "orderBy": {
-          "path": {
-            "field": [
-              "a"
-            ]
+  "tests": [
+    {
+      "description": "query: Delete in cursor method",
+      "comment": "Sentinel values are not permitted in queries.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
+          {
+            "orderBy": {
+              "path": {
+                "field": [
+                  "a"
+                ]
+              },
+              "direction": "asc"
+            }
           },
-          "direction": "asc"
-        }
-      },
-      {
-        "endBefore": {
-          "jsonValues": [
-            "\"Delete\""
-          ]
-        }
+          {
+            "endBefore": {
+              "jsonValues": [
+                "\"Delete\""
+              ]
+            }
+          }
+        ],
+        "isError": true
       }
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/query-del-where.json
+++ b/firestore/v1/testcase/query-del-where.json
@@ -1,0 +1,21 @@
+{
+  "description": "query: Delete in Where",
+  "comment": "Sentinel values are not permitted in queries.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "where": {
+          "path": {
+            "field": [
+              "a"
+            ]
+          },
+          "op": "==",
+          "jsonValue": "\"Delete\""
+        }
+      }
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/query-del-where.json
+++ b/firestore/v1/testcase/query-del-where.json
@@ -1,21 +1,25 @@
 {
-  "description": "query: Delete in Where",
-  "comment": "Sentinel values are not permitted in queries.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "where": {
-          "path": {
-            "field": [
-              "a"
-            ]
-          },
-          "op": "==",
-          "jsonValue": "\"Delete\""
-        }
+  "tests": [
+    {
+      "description": "query: Delete in Where",
+      "comment": "Sentinel values are not permitted in queries.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
+          {
+            "where": {
+              "path": {
+                "field": [
+                  "a"
+                ]
+              },
+              "op": "==",
+              "jsonValue": "\"Delete\""
+            }
+          }
+        ],
+        "isError": true
       }
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/query-invalid-operator.json
+++ b/firestore/v1/testcase/query-invalid-operator.json
@@ -1,0 +1,21 @@
+{
+  "description": "query: invalid operator in Where clause",
+  "comment": "The !=  operator is not supported.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "where": {
+          "path": {
+            "field": [
+              "a"
+            ]
+          },
+          "op": "!=",
+          "jsonValue": "4"
+        }
+      }
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/query-invalid-operator.json
+++ b/firestore/v1/testcase/query-invalid-operator.json
@@ -1,21 +1,25 @@
 {
-  "description": "query: invalid operator in Where clause",
-  "comment": "The !=  operator is not supported.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "where": {
-          "path": {
-            "field": [
-              "a"
-            ]
-          },
-          "op": "!=",
-          "jsonValue": "4"
-        }
+  "tests": [
+    {
+      "description": "query: invalid operator in Where clause",
+      "comment": "The !=  operator is not supported.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
+          {
+            "where": {
+              "path": {
+                "field": [
+                  "a"
+                ]
+              },
+              "op": "!=",
+              "jsonValue": "4"
+            }
+          }
+        ],
+        "isError": true
       }
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/query-invalid-path-order.json
+++ b/firestore/v1/testcase/query-invalid-path-order.json
@@ -1,0 +1,21 @@
+{
+  "description": "query: invalid path in OrderBy clause",
+  "comment": "The path has an empty component.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "orderBy": {
+          "path": {
+            "field": [
+              "*",
+              ""
+            ]
+          },
+          "direction": "asc"
+        }
+      }
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/query-invalid-path-order.json
+++ b/firestore/v1/testcase/query-invalid-path-order.json
@@ -1,21 +1,25 @@
 {
-  "description": "query: invalid path in OrderBy clause",
-  "comment": "The path has an empty component.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "orderBy": {
-          "path": {
-            "field": [
-              "*",
-              ""
-            ]
-          },
-          "direction": "asc"
-        }
+  "tests": [
+    {
+      "description": "query: invalid path in OrderBy clause",
+      "comment": "The path has an empty component.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
+          {
+            "orderBy": {
+              "path": {
+                "field": [
+                  "*",
+                  ""
+                ]
+              },
+              "direction": "asc"
+            }
+          }
+        ],
+        "isError": true
       }
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/query-invalid-path-select.json
+++ b/firestore/v1/testcase/query-invalid-path-select.json
@@ -1,0 +1,22 @@
+{
+  "description": "query: invalid path in Where clause",
+  "comment": "The path has an empty component.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "select": {
+          "fields": [
+            {
+              "field": [
+                "*",
+                ""
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/query-invalid-path-select.json
+++ b/firestore/v1/testcase/query-invalid-path-select.json
@@ -1,22 +1,26 @@
 {
-  "description": "query: invalid path in Where clause",
-  "comment": "The path has an empty component.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "select": {
-          "fields": [
-            {
-              "field": [
-                "*",
-                ""
+  "tests": [
+    {
+      "description": "query: invalid path in Where clause",
+      "comment": "The path has an empty component.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
+          {
+            "select": {
+              "fields": [
+                {
+                  "field": [
+                    "*",
+                    ""
+                  ]
+                }
               ]
             }
-          ]
-        }
+          }
+        ],
+        "isError": true
       }
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/query-invalid-path-where.json
+++ b/firestore/v1/testcase/query-invalid-path-where.json
@@ -1,0 +1,22 @@
+{
+  "description": "query: invalid path in Where clause",
+  "comment": "The path has an empty component.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "where": {
+          "path": {
+            "field": [
+              "*",
+              ""
+            ]
+          },
+          "op": "==",
+          "jsonValue": "4"
+        }
+      }
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/query-invalid-path-where.json
+++ b/firestore/v1/testcase/query-invalid-path-where.json
@@ -1,22 +1,26 @@
 {
-  "description": "query: invalid path in Where clause",
-  "comment": "The path has an empty component.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "where": {
-          "path": {
-            "field": [
-              "*",
-              ""
-            ]
-          },
-          "op": "==",
-          "jsonValue": "4"
-        }
+  "tests": [
+    {
+      "description": "query: invalid path in Where clause",
+      "comment": "The path has an empty component.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
+          {
+            "where": {
+              "path": {
+                "field": [
+                  "*",
+                  ""
+                ]
+              },
+              "op": "==",
+              "jsonValue": "4"
+            }
+          }
+        ],
+        "isError": true
       }
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/query-offset-limit-last-wins.json
+++ b/firestore/v1/testcase/query-offset-limit-last-wins.json
@@ -1,0 +1,30 @@
+{
+  "description": "query: multiple Offset and Limit clauses",
+  "comment": "With multiple Offset or Limit clauses, the last one wins.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "offset": 2
+      },
+      {
+        "limit": 3
+      },
+      {
+        "limit": 4
+      },
+      {
+        "offset": 5
+      }
+    ],
+    "query": {
+      "from": [
+        {
+          "collectionId": "C"
+        }
+      ],
+      "offset": 5,
+      "limit": 4
+    }
+  }
+}

--- a/firestore/v1/testcase/query-offset-limit-last-wins.json
+++ b/firestore/v1/testcase/query-offset-limit-last-wins.json
@@ -1,30 +1,34 @@
 {
-  "description": "query: multiple Offset and Limit clauses",
-  "comment": "With multiple Offset or Limit clauses, the last one wins.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "offset": 2
-      },
-      {
-        "limit": 3
-      },
-      {
-        "limit": 4
-      },
-      {
-        "offset": 5
-      }
-    ],
-    "query": {
-      "from": [
-        {
-          "collectionId": "C"
+  "tests": [
+    {
+      "description": "query: multiple Offset and Limit clauses",
+      "comment": "With multiple Offset or Limit clauses, the last one wins.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
+          {
+            "offset": 2
+          },
+          {
+            "limit": 3
+          },
+          {
+            "limit": 4
+          },
+          {
+            "offset": 5
+          }
+        ],
+        "query": {
+          "from": [
+            {
+              "collectionId": "C"
+            }
+          ],
+          "offset": 5,
+          "limit": 4
         }
-      ],
-      "offset": 5,
-      "limit": 4
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/query-offset-limit.json
+++ b/firestore/v1/testcase/query-offset-limit.json
@@ -1,0 +1,24 @@
+{
+  "description": "query: Offset and Limit clauses",
+  "comment": "Offset and Limit clauses.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "offset": 2
+      },
+      {
+        "limit": 3
+      }
+    ],
+    "query": {
+      "from": [
+        {
+          "collectionId": "C"
+        }
+      ],
+      "offset": 2,
+      "limit": 3
+    }
+  }
+}

--- a/firestore/v1/testcase/query-offset-limit.json
+++ b/firestore/v1/testcase/query-offset-limit.json
@@ -1,24 +1,28 @@
 {
-  "description": "query: Offset and Limit clauses",
-  "comment": "Offset and Limit clauses.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "offset": 2
-      },
-      {
-        "limit": 3
-      }
-    ],
-    "query": {
-      "from": [
-        {
-          "collectionId": "C"
+  "tests": [
+    {
+      "description": "query: Offset and Limit clauses",
+      "comment": "Offset and Limit clauses.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
+          {
+            "offset": 2
+          },
+          {
+            "limit": 3
+          }
+        ],
+        "query": {
+          "from": [
+            {
+              "collectionId": "C"
+            }
+          ],
+          "offset": 2,
+          "limit": 3
         }
-      ],
-      "offset": 2,
-      "limit": 3
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/query-order.json
+++ b/firestore/v1/testcase/query-order.json
@@ -1,0 +1,50 @@
+{
+  "description": "query: basic OrderBy clauses",
+  "comment": "Multiple OrderBy clauses combine.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "orderBy": {
+          "path": {
+            "field": [
+              "b"
+            ]
+          },
+          "direction": "asc"
+        }
+      },
+      {
+        "orderBy": {
+          "path": {
+            "field": [
+              "a"
+            ]
+          },
+          "direction": "desc"
+        }
+      }
+    ],
+    "query": {
+      "from": [
+        {
+          "collectionId": "C"
+        }
+      ],
+      "orderBy": [
+        {
+          "field": {
+            "fieldPath": "b"
+          },
+          "direction": "ASCENDING"
+        },
+        {
+          "field": {
+            "fieldPath": "a"
+          },
+          "direction": "DESCENDING"
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/query-order.json
+++ b/firestore/v1/testcase/query-order.json
@@ -1,50 +1,54 @@
 {
-  "description": "query: basic OrderBy clauses",
-  "comment": "Multiple OrderBy clauses combine.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "orderBy": {
-          "path": {
-            "field": [
-              "b"
-            ]
+  "tests": [
+    {
+      "description": "query: basic OrderBy clauses",
+      "comment": "Multiple OrderBy clauses combine.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
+          {
+            "orderBy": {
+              "path": {
+                "field": [
+                  "b"
+                ]
+              },
+              "direction": "asc"
+            }
           },
-          "direction": "asc"
-        }
-      },
-      {
-        "orderBy": {
-          "path": {
-            "field": [
-              "a"
-            ]
-          },
-          "direction": "desc"
+          {
+            "orderBy": {
+              "path": {
+                "field": [
+                  "a"
+                ]
+              },
+              "direction": "desc"
+            }
+          }
+        ],
+        "query": {
+          "from": [
+            {
+              "collectionId": "C"
+            }
+          ],
+          "orderBy": [
+            {
+              "field": {
+                "fieldPath": "b"
+              },
+              "direction": "ASCENDING"
+            },
+            {
+              "field": {
+                "fieldPath": "a"
+              },
+              "direction": "DESCENDING"
+            }
+          ]
         }
       }
-    ],
-    "query": {
-      "from": [
-        {
-          "collectionId": "C"
-        }
-      ],
-      "orderBy": [
-        {
-          "field": {
-            "fieldPath": "b"
-          },
-          "direction": "ASCENDING"
-        },
-        {
-          "field": {
-            "fieldPath": "a"
-          },
-          "direction": "DESCENDING"
-        }
-      ]
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/query-select-empty.json
+++ b/firestore/v1/testcase/query-select-empty.json
@@ -1,0 +1,28 @@
+{
+  "description": "query: empty Select clause",
+  "comment": "An empty Select clause selects just the document ID.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "select": {
+          "fields": []
+        }
+      }
+    ],
+    "query": {
+      "select": {
+        "fields": [
+          {
+            "fieldPath": "__name__"
+          }
+        ]
+      },
+      "from": [
+        {
+          "collectionId": "C"
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/query-select-empty.json
+++ b/firestore/v1/testcase/query-select-empty.json
@@ -1,28 +1,32 @@
 {
-  "description": "query: empty Select clause",
-  "comment": "An empty Select clause selects just the document ID.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "select": {
-          "fields": []
+  "tests": [
+    {
+      "description": "query: empty Select clause",
+      "comment": "An empty Select clause selects just the document ID.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
+          {
+            "select": {
+              "fields": []
+            }
+          }
+        ],
+        "query": {
+          "select": {
+            "fields": [
+              {
+                "fieldPath": "__name__"
+              }
+            ]
+          },
+          "from": [
+            {
+              "collectionId": "C"
+            }
+          ]
         }
       }
-    ],
-    "query": {
-      "select": {
-        "fields": [
-          {
-            "fieldPath": "__name__"
-          }
-        ]
-      },
-      "from": [
-        {
-          "collectionId": "C"
-        }
-      ]
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/query-select-last-wins.json
+++ b/firestore/v1/testcase/query-select-last-wins.json
@@ -1,0 +1,50 @@
+{
+  "description": "query: two Select clauses",
+  "comment": "The last Select clause is the only one used.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "select": {
+          "fields": [
+            {
+              "field": [
+                "a"
+              ]
+            },
+            {
+              "field": [
+                "b"
+              ]
+            }
+          ]
+        }
+      },
+      {
+        "select": {
+          "fields": [
+            {
+              "field": [
+                "c"
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "query": {
+      "select": {
+        "fields": [
+          {
+            "fieldPath": "c"
+          }
+        ]
+      },
+      "from": [
+        {
+          "collectionId": "C"
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/query-select-last-wins.json
+++ b/firestore/v1/testcase/query-select-last-wins.json
@@ -1,50 +1,54 @@
 {
-  "description": "query: two Select clauses",
-  "comment": "The last Select clause is the only one used.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "select": {
-          "fields": [
-            {
-              "field": [
-                "a"
-              ]
-            },
-            {
-              "field": [
-                "b"
+  "tests": [
+    {
+      "description": "query: two Select clauses",
+      "comment": "The last Select clause is the only one used.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
+          {
+            "select": {
+              "fields": [
+                {
+                  "field": [
+                    "a"
+                  ]
+                },
+                {
+                  "field": [
+                    "b"
+                  ]
+                }
               ]
             }
-          ]
-        }
-      },
-      {
-        "select": {
-          "fields": [
-            {
-              "field": [
-                "c"
+          },
+          {
+            "select": {
+              "fields": [
+                {
+                  "field": [
+                    "c"
+                  ]
+                }
               ]
+            }
+          }
+        ],
+        "query": {
+          "select": {
+            "fields": [
+              {
+                "fieldPath": "c"
+              }
+            ]
+          },
+          "from": [
+            {
+              "collectionId": "C"
             }
           ]
         }
       }
-    ],
-    "query": {
-      "select": {
-        "fields": [
-          {
-            "fieldPath": "c"
-          }
-        ]
-      },
-      "from": [
-        {
-          "collectionId": "C"
-        }
-      ]
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/query-select.json
+++ b/firestore/v1/testcase/query-select.json
@@ -1,0 +1,42 @@
+{
+  "description": "query: Select clause with some fields",
+  "comment": "An ordinary Select clause.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "select": {
+          "fields": [
+            {
+              "field": [
+                "a"
+              ]
+            },
+            {
+              "field": [
+                "b"
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "query": {
+      "select": {
+        "fields": [
+          {
+            "fieldPath": "a"
+          },
+          {
+            "fieldPath": "b"
+          }
+        ]
+      },
+      "from": [
+        {
+          "collectionId": "C"
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/query-select.json
+++ b/firestore/v1/testcase/query-select.json
@@ -1,42 +1,46 @@
 {
-  "description": "query: Select clause with some fields",
-  "comment": "An ordinary Select clause.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "select": {
-          "fields": [
-            {
-              "field": [
-                "a"
+  "tests": [
+    {
+      "description": "query: Select clause with some fields",
+      "comment": "An ordinary Select clause.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
+          {
+            "select": {
+              "fields": [
+                {
+                  "field": [
+                    "a"
+                  ]
+                },
+                {
+                  "field": [
+                    "b"
+                  ]
+                }
               ]
-            },
+            }
+          }
+        ],
+        "query": {
+          "select": {
+            "fields": [
+              {
+                "fieldPath": "a"
+              },
+              {
+                "fieldPath": "b"
+              }
+            ]
+          },
+          "from": [
             {
-              "field": [
-                "b"
-              ]
+              "collectionId": "C"
             }
           ]
         }
       }
-    ],
-    "query": {
-      "select": {
-        "fields": [
-          {
-            "fieldPath": "a"
-          },
-          {
-            "fieldPath": "b"
-          }
-        ]
-      },
-      "from": [
-        {
-          "collectionId": "C"
-        }
-      ]
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/query-st-cursor.json
+++ b/firestore/v1/testcase/query-st-cursor.json
@@ -1,0 +1,27 @@
+{
+  "description": "query: ServerTimestamp in cursor method",
+  "comment": "Sentinel values are not permitted in queries.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "orderBy": {
+          "path": {
+            "field": [
+              "a"
+            ]
+          },
+          "direction": "asc"
+        }
+      },
+      {
+        "endBefore": {
+          "jsonValues": [
+            "\"ServerTimestamp\""
+          ]
+        }
+      }
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/query-st-cursor.json
+++ b/firestore/v1/testcase/query-st-cursor.json
@@ -1,27 +1,31 @@
 {
-  "description": "query: ServerTimestamp in cursor method",
-  "comment": "Sentinel values are not permitted in queries.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "orderBy": {
-          "path": {
-            "field": [
-              "a"
-            ]
+  "tests": [
+    {
+      "description": "query: ServerTimestamp in cursor method",
+      "comment": "Sentinel values are not permitted in queries.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
+          {
+            "orderBy": {
+              "path": {
+                "field": [
+                  "a"
+                ]
+              },
+              "direction": "asc"
+            }
           },
-          "direction": "asc"
-        }
-      },
-      {
-        "endBefore": {
-          "jsonValues": [
-            "\"ServerTimestamp\""
-          ]
-        }
+          {
+            "endBefore": {
+              "jsonValues": [
+                "\"ServerTimestamp\""
+              ]
+            }
+          }
+        ],
+        "isError": true
       }
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/query-st-where.json
+++ b/firestore/v1/testcase/query-st-where.json
@@ -1,0 +1,21 @@
+{
+  "description": "query: ServerTimestamp in Where",
+  "comment": "Sentinel values are not permitted in queries.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "where": {
+          "path": {
+            "field": [
+              "a"
+            ]
+          },
+          "op": "==",
+          "jsonValue": "\"ServerTimestamp\""
+        }
+      }
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/query-st-where.json
+++ b/firestore/v1/testcase/query-st-where.json
@@ -1,21 +1,25 @@
 {
-  "description": "query: ServerTimestamp in Where",
-  "comment": "Sentinel values are not permitted in queries.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "where": {
-          "path": {
-            "field": [
-              "a"
-            ]
-          },
-          "op": "==",
-          "jsonValue": "\"ServerTimestamp\""
-        }
+  "tests": [
+    {
+      "description": "query: ServerTimestamp in Where",
+      "comment": "Sentinel values are not permitted in queries.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
+          {
+            "where": {
+              "path": {
+                "field": [
+                  "a"
+                ]
+              },
+              "op": "==",
+              "jsonValue": "\"ServerTimestamp\""
+            }
+          }
+        ],
+        "isError": true
       }
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/query-where-2.json
+++ b/firestore/v1/testcase/query-where-2.json
@@ -1,0 +1,67 @@
+{
+  "description": "query: two Where clauses",
+  "comment": "Multiple Where clauses are combined into a composite filter.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "where": {
+          "path": {
+            "field": [
+              "a"
+            ]
+          },
+          "op": "\u003e=",
+          "jsonValue": "5"
+        }
+      },
+      {
+        "where": {
+          "path": {
+            "field": [
+              "b"
+            ]
+          },
+          "op": "\u003c",
+          "jsonValue": "\"foo\""
+        }
+      }
+    ],
+    "query": {
+      "from": [
+        {
+          "collectionId": "C"
+        }
+      ],
+      "where": {
+        "compositeFilter": {
+          "op": "AND",
+          "filters": [
+            {
+              "fieldFilter": {
+                "field": {
+                  "fieldPath": "a"
+                },
+                "op": "GREATER_THAN_OR_EQUAL",
+                "value": {
+                  "integerValue": "5"
+                }
+              }
+            },
+            {
+              "fieldFilter": {
+                "field": {
+                  "fieldPath": "b"
+                },
+                "op": "LESS_THAN",
+                "value": {
+                  "stringValue": "foo"
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/firestore/v1/testcase/query-where-2.json
+++ b/firestore/v1/testcase/query-where-2.json
@@ -1,67 +1,71 @@
 {
-  "description": "query: two Where clauses",
-  "comment": "Multiple Where clauses are combined into a composite filter.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "where": {
-          "path": {
-            "field": [
-              "a"
-            ]
-          },
-          "op": "\u003e=",
-          "jsonValue": "5"
-        }
-      },
-      {
-        "where": {
-          "path": {
-            "field": [
-              "b"
-            ]
-          },
-          "op": "\u003c",
-          "jsonValue": "\"foo\""
-        }
-      }
-    ],
-    "query": {
-      "from": [
-        {
-          "collectionId": "C"
-        }
-      ],
-      "where": {
-        "compositeFilter": {
-          "op": "AND",
-          "filters": [
-            {
-              "fieldFilter": {
-                "field": {
-                  "fieldPath": "a"
-                },
-                "op": "GREATER_THAN_OR_EQUAL",
-                "value": {
-                  "integerValue": "5"
-                }
-              }
-            },
-            {
-              "fieldFilter": {
-                "field": {
-                  "fieldPath": "b"
-                },
-                "op": "LESS_THAN",
-                "value": {
-                  "stringValue": "foo"
-                }
-              }
+  "tests": [
+    {
+      "description": "query: two Where clauses",
+      "comment": "Multiple Where clauses are combined into a composite filter.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
+          {
+            "where": {
+              "path": {
+                "field": [
+                  "a"
+                ]
+              },
+              "op": "\u003e=",
+              "jsonValue": "5"
             }
-          ]
+          },
+          {
+            "where": {
+              "path": {
+                "field": [
+                  "b"
+                ]
+              },
+              "op": "\u003c",
+              "jsonValue": "\"foo\""
+            }
+          }
+        ],
+        "query": {
+          "from": [
+            {
+              "collectionId": "C"
+            }
+          ],
+          "where": {
+            "compositeFilter": {
+              "op": "AND",
+              "filters": [
+                {
+                  "fieldFilter": {
+                    "field": {
+                      "fieldPath": "a"
+                    },
+                    "op": "GREATER_THAN_OR_EQUAL",
+                    "value": {
+                      "integerValue": "5"
+                    }
+                  }
+                },
+                {
+                  "fieldFilter": {
+                    "field": {
+                      "fieldPath": "b"
+                    },
+                    "op": "LESS_THAN",
+                    "value": {
+                      "stringValue": "foo"
+                    }
+                  }
+                }
+              ]
+            }
+          }
         }
       }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/query-where-NaN.json
+++ b/firestore/v1/testcase/query-where-NaN.json
@@ -1,0 +1,35 @@
+{
+  "description": "query: a Where clause comparing to NaN",
+  "comment": "A Where clause that tests for equality with NaN results in a unary filter.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "where": {
+          "path": {
+            "field": [
+              "a"
+            ]
+          },
+          "op": "==",
+          "jsonValue": "\"NaN\""
+        }
+      }
+    ],
+    "query": {
+      "from": [
+        {
+          "collectionId": "C"
+        }
+      ],
+      "where": {
+        "unaryFilter": {
+          "op": "IS_NAN",
+          "field": {
+            "fieldPath": "a"
+          }
+        }
+      }
+    }
+  }
+}

--- a/firestore/v1/testcase/query-where-NaN.json
+++ b/firestore/v1/testcase/query-where-NaN.json
@@ -1,35 +1,39 @@
 {
-  "description": "query: a Where clause comparing to NaN",
-  "comment": "A Where clause that tests for equality with NaN results in a unary filter.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "where": {
-          "path": {
-            "field": [
-              "a"
-            ]
-          },
-          "op": "==",
-          "jsonValue": "\"NaN\""
-        }
-      }
-    ],
-    "query": {
-      "from": [
-        {
-          "collectionId": "C"
-        }
-      ],
-      "where": {
-        "unaryFilter": {
-          "op": "IS_NAN",
-          "field": {
-            "fieldPath": "a"
+  "tests": [
+    {
+      "description": "query: a Where clause comparing to NaN",
+      "comment": "A Where clause that tests for equality with NaN results in a unary filter.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
+          {
+            "where": {
+              "path": {
+                "field": [
+                  "a"
+                ]
+              },
+              "op": "==",
+              "jsonValue": "\"NaN\""
+            }
+          }
+        ],
+        "query": {
+          "from": [
+            {
+              "collectionId": "C"
+            }
+          ],
+          "where": {
+            "unaryFilter": {
+              "op": "IS_NAN",
+              "field": {
+                "fieldPath": "a"
+              }
+            }
           }
         }
       }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/query-where-null.json
+++ b/firestore/v1/testcase/query-where-null.json
@@ -1,0 +1,35 @@
+{
+  "description": "query: a Where clause comparing to null",
+  "comment": "A Where clause that tests for equality with null results in a unary filter.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "where": {
+          "path": {
+            "field": [
+              "a"
+            ]
+          },
+          "op": "==",
+          "jsonValue": "null"
+        }
+      }
+    ],
+    "query": {
+      "from": [
+        {
+          "collectionId": "C"
+        }
+      ],
+      "where": {
+        "unaryFilter": {
+          "op": "IS_NULL",
+          "field": {
+            "fieldPath": "a"
+          }
+        }
+      }
+    }
+  }
+}

--- a/firestore/v1/testcase/query-where-null.json
+++ b/firestore/v1/testcase/query-where-null.json
@@ -1,35 +1,39 @@
 {
-  "description": "query: a Where clause comparing to null",
-  "comment": "A Where clause that tests for equality with null results in a unary filter.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "where": {
-          "path": {
-            "field": [
-              "a"
-            ]
-          },
-          "op": "==",
-          "jsonValue": "null"
-        }
-      }
-    ],
-    "query": {
-      "from": [
-        {
-          "collectionId": "C"
-        }
-      ],
-      "where": {
-        "unaryFilter": {
-          "op": "IS_NULL",
-          "field": {
-            "fieldPath": "a"
+  "tests": [
+    {
+      "description": "query: a Where clause comparing to null",
+      "comment": "A Where clause that tests for equality with null results in a unary filter.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
+          {
+            "where": {
+              "path": {
+                "field": [
+                  "a"
+                ]
+              },
+              "op": "==",
+              "jsonValue": "null"
+            }
+          }
+        ],
+        "query": {
+          "from": [
+            {
+              "collectionId": "C"
+            }
+          ],
+          "where": {
+            "unaryFilter": {
+              "op": "IS_NULL",
+              "field": {
+                "fieldPath": "a"
+              }
+            }
           }
         }
       }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/query-where.json
+++ b/firestore/v1/testcase/query-where.json
@@ -1,0 +1,38 @@
+{
+  "description": "query: Where clause",
+  "comment": "A simple Where clause.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "where": {
+          "path": {
+            "field": [
+              "a"
+            ]
+          },
+          "op": "\u003e",
+          "jsonValue": "5"
+        }
+      }
+    ],
+    "query": {
+      "from": [
+        {
+          "collectionId": "C"
+        }
+      ],
+      "where": {
+        "fieldFilter": {
+          "field": {
+            "fieldPath": "a"
+          },
+          "op": "GREATER_THAN",
+          "value": {
+            "integerValue": "5"
+          }
+        }
+      }
+    }
+  }
+}

--- a/firestore/v1/testcase/query-where.json
+++ b/firestore/v1/testcase/query-where.json
@@ -1,38 +1,42 @@
 {
-  "description": "query: Where clause",
-  "comment": "A simple Where clause.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "where": {
-          "path": {
-            "field": [
-              "a"
-            ]
-          },
-          "op": "\u003e",
-          "jsonValue": "5"
-        }
-      }
-    ],
-    "query": {
-      "from": [
-        {
-          "collectionId": "C"
-        }
-      ],
-      "where": {
-        "fieldFilter": {
-          "field": {
-            "fieldPath": "a"
-          },
-          "op": "GREATER_THAN",
-          "value": {
-            "integerValue": "5"
+  "tests": [
+    {
+      "description": "query: Where clause",
+      "comment": "A simple Where clause.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
+          {
+            "where": {
+              "path": {
+                "field": [
+                  "a"
+                ]
+              },
+              "op": "\u003e",
+              "jsonValue": "5"
+            }
+          }
+        ],
+        "query": {
+          "from": [
+            {
+              "collectionId": "C"
+            }
+          ],
+          "where": {
+            "fieldFilter": {
+              "field": {
+                "fieldPath": "a"
+              },
+              "op": "GREATER_THAN",
+              "value": {
+                "integerValue": "5"
+              }
+            }
           }
         }
       }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/query-wrong-collection.json
+++ b/firestore/v1/testcase/query-wrong-collection.json
@@ -1,0 +1,18 @@
+{
+  "description": "query: doc snapshot with wrong collection in cursor method",
+  "comment": "If a document snapshot is passed to a Start*/End* method, it must be in the\nsame collection as the query.",
+  "query": {
+    "collPath": "projects/projectID/databases/(default)/documents/C",
+    "clauses": [
+      {
+        "endBefore": {
+          "docSnapshot": {
+            "path": "projects/projectID/databases/(default)/documents/C2/D",
+            "jsonData": "{\"a\": 7, \"b\": 8}"
+          }
+        }
+      }
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/query-wrong-collection.json
+++ b/firestore/v1/testcase/query-wrong-collection.json
@@ -1,18 +1,22 @@
 {
-  "description": "query: doc snapshot with wrong collection in cursor method",
-  "comment": "If a document snapshot is passed to a Start*/End* method, it must be in the\nsame collection as the query.",
-  "query": {
-    "collPath": "projects/projectID/databases/(default)/documents/C",
-    "clauses": [
-      {
-        "endBefore": {
-          "docSnapshot": {
-            "path": "projects/projectID/databases/(default)/documents/C2/D",
-            "jsonData": "{\"a\": 7, \"b\": 8}"
+  "tests": [
+    {
+      "description": "query: doc snapshot with wrong collection in cursor method",
+      "comment": "If a document snapshot is passed to a Start*/End* method, it must be in the\nsame collection as the query.",
+      "query": {
+        "collPath": "projects/projectID/databases/(default)/documents/C",
+        "clauses": [
+          {
+            "endBefore": {
+              "docSnapshot": {
+                "path": "projects/projectID/databases/(default)/documents/C2/D",
+                "jsonData": "{\"a\": 7, \"b\": 8}"
+              }
+            }
           }
-        }
+        ],
+        "isError": true
       }
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/set-all-transforms.json
+++ b/firestore/v1/testcase/set-all-transforms.json
@@ -1,0 +1,66 @@
+{
+  "description": "set: all transforms in a single call",
+  "comment": "A document can be created with any amount of transforms.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\", \"c\": [\"ArrayUnion\", 1, 2, 3], \"d\": [\"ArrayRemove\", 4, 5, 6]}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b",
+                "setToServerValue": "REQUEST_TIME"
+              },
+              {
+                "fieldPath": "c",
+                "appendMissingElements": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "integerValue": "2"
+                    },
+                    {
+                      "integerValue": "3"
+                    }
+                  ]
+                }
+              },
+              {
+                "fieldPath": "d",
+                "removeAllFromArray": {
+                  "values": [
+                    {
+                      "integerValue": "4"
+                    },
+                    {
+                      "integerValue": "5"
+                    },
+                    {
+                      "integerValue": "6"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/set-all-transforms.json
+++ b/firestore/v1/testcase/set-all-transforms.json
@@ -1,66 +1,70 @@
 {
-  "description": "set: all transforms in a single call",
-  "comment": "A document can be created with any amount of transforms.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\", \"c\": [\"ArrayUnion\", 1, 2, 3], \"d\": [\"ArrayRemove\", 4, 5, 6]}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
+  "tests": [
+    {
+      "description": "set: all transforms in a single call",
+      "comment": "A document can be created with any amount of transforms.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\", \"c\": [\"ArrayUnion\", 1, 2, 3], \"d\": [\"ArrayRemove\", 4, 5, 6]}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b",
+                    "setToServerValue": "REQUEST_TIME"
+                  },
+                  {
+                    "fieldPath": "c",
+                    "appendMissingElements": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "integerValue": "2"
+                        },
+                        {
+                          "integerValue": "3"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "fieldPath": "d",
+                    "removeAllFromArray": {
+                      "values": [
+                        {
+                          "integerValue": "4"
+                        },
+                        {
+                          "integerValue": "5"
+                        },
+                        {
+                          "integerValue": "6"
+                        }
+                      ]
+                    }
+                  }
+                ]
               }
             }
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b",
-                "setToServerValue": "REQUEST_TIME"
-              },
-              {
-                "fieldPath": "c",
-                "appendMissingElements": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "integerValue": "2"
-                    },
-                    {
-                      "integerValue": "3"
-                    }
-                  ]
-                }
-              },
-              {
-                "fieldPath": "d",
-                "removeAllFromArray": {
-                  "values": [
-                    {
-                      "integerValue": "4"
-                    },
-                    {
-                      "integerValue": "5"
-                    },
-                    {
-                      "integerValue": "6"
-                    }
-                  ]
-                }
-              }
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/set-arrayremove-multi.json
+++ b/firestore/v1/testcase/set-arrayremove-multi.json
@@ -1,0 +1,62 @@
+{
+  "description": "set: multiple ArrayRemove fields",
+  "comment": "A document can have more than one ArrayRemove field.\nSince all the ArrayRemove fields are removed, the only field in the update is \"a\".",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b\": [\"ArrayRemove\", 1, 2, 3], \"c\": {\"d\": [\"ArrayRemove\", 4, 5, 6]}}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b",
+                "removeAllFromArray": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "integerValue": "2"
+                    },
+                    {
+                      "integerValue": "3"
+                    }
+                  ]
+                }
+              },
+              {
+                "fieldPath": "c.d",
+                "removeAllFromArray": {
+                  "values": [
+                    {
+                      "integerValue": "4"
+                    },
+                    {
+                      "integerValue": "5"
+                    },
+                    {
+                      "integerValue": "6"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/set-arrayremove-multi.json
+++ b/firestore/v1/testcase/set-arrayremove-multi.json
@@ -1,62 +1,66 @@
 {
-  "description": "set: multiple ArrayRemove fields",
-  "comment": "A document can have more than one ArrayRemove field.\nSince all the ArrayRemove fields are removed, the only field in the update is \"a\".",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b\": [\"ArrayRemove\", 1, 2, 3], \"c\": {\"d\": [\"ArrayRemove\", 4, 5, 6]}}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
+  "tests": [
+    {
+      "description": "set: multiple ArrayRemove fields",
+      "comment": "A document can have more than one ArrayRemove field.\nSince all the ArrayRemove fields are removed, the only field in the update is \"a\".",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b\": [\"ArrayRemove\", 1, 2, 3], \"c\": {\"d\": [\"ArrayRemove\", 4, 5, 6]}}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b",
+                    "removeAllFromArray": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "integerValue": "2"
+                        },
+                        {
+                          "integerValue": "3"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "fieldPath": "c.d",
+                    "removeAllFromArray": {
+                      "values": [
+                        {
+                          "integerValue": "4"
+                        },
+                        {
+                          "integerValue": "5"
+                        },
+                        {
+                          "integerValue": "6"
+                        }
+                      ]
+                    }
+                  }
+                ]
               }
             }
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b",
-                "removeAllFromArray": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "integerValue": "2"
-                    },
-                    {
-                      "integerValue": "3"
-                    }
-                  ]
-                }
-              },
-              {
-                "fieldPath": "c.d",
-                "removeAllFromArray": {
-                  "values": [
-                    {
-                      "integerValue": "4"
-                    },
-                    {
-                      "integerValue": "5"
-                    },
-                    {
-                      "integerValue": "6"
-                    }
-                  ]
-                }
-              }
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/set-arrayremove-nested.json
+++ b/firestore/v1/testcase/set-arrayremove-nested.json
@@ -1,0 +1,46 @@
+{
+  "description": "set: nested ArrayRemove field",
+  "comment": "An ArrayRemove value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b\": {\"c\": [\"ArrayRemove\", 1, 2, 3]}}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b.c",
+                "removeAllFromArray": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "integerValue": "2"
+                    },
+                    {
+                      "integerValue": "3"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/set-arrayremove-nested.json
+++ b/firestore/v1/testcase/set-arrayremove-nested.json
@@ -1,46 +1,50 @@
 {
-  "description": "set: nested ArrayRemove field",
-  "comment": "An ArrayRemove value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b\": {\"c\": [\"ArrayRemove\", 1, 2, 3]}}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            }
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b.c",
-                "removeAllFromArray": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "integerValue": "2"
-                    },
-                    {
-                      "integerValue": "3"
-                    }
-                  ]
+  "tests": [
+    {
+      "description": "set: nested ArrayRemove field",
+      "comment": "An ArrayRemove value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b\": {\"c\": [\"ArrayRemove\", 1, 2, 3]}}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
                 }
               }
-            ]
-          }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b.c",
+                    "removeAllFromArray": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "integerValue": "2"
+                        },
+                        {
+                          "integerValue": "3"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/set-arrayremove-noarray-nested.json
+++ b/firestore/v1/testcase/set-arrayremove-noarray-nested.json
@@ -1,0 +1,9 @@
+{
+  "description": "set: ArrayRemove cannot be anywhere inside an array value",
+  "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ArrayRemove. Firestore transforms don't support array indexing.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [1, {\"b\": [\"ArrayRemove\", 1, 2, 3]}]}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/set-arrayremove-noarray-nested.json
+++ b/firestore/v1/testcase/set-arrayremove-noarray-nested.json
@@ -1,9 +1,13 @@
 {
-  "description": "set: ArrayRemove cannot be anywhere inside an array value",
-  "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ArrayRemove. Firestore transforms don't support array indexing.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [1, {\"b\": [\"ArrayRemove\", 1, 2, 3]}]}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "set: ArrayRemove cannot be anywhere inside an array value",
+      "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ArrayRemove. Firestore transforms don't support array indexing.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [1, {\"b\": [\"ArrayRemove\", 1, 2, 3]}]}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/set-arrayremove-noarray.json
+++ b/firestore/v1/testcase/set-arrayremove-noarray.json
@@ -1,0 +1,9 @@
+{
+  "description": "set: ArrayRemove cannot be in an array value",
+  "comment": "ArrayRemove must be the value of a field. Firestore\ntransforms don't support array indexing.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [1, 2, [\"ArrayRemove\", 1, 2, 3]]}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/set-arrayremove-noarray.json
+++ b/firestore/v1/testcase/set-arrayremove-noarray.json
@@ -1,9 +1,13 @@
 {
-  "description": "set: ArrayRemove cannot be in an array value",
-  "comment": "ArrayRemove must be the value of a field. Firestore\ntransforms don't support array indexing.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [1, 2, [\"ArrayRemove\", 1, 2, 3]]}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "set: ArrayRemove cannot be in an array value",
+      "comment": "ArrayRemove must be the value of a field. Firestore\ntransforms don't support array indexing.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [1, 2, [\"ArrayRemove\", 1, 2, 3]]}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/set-arrayremove-with-st.json
+++ b/firestore/v1/testcase/set-arrayremove-with-st.json
@@ -1,0 +1,9 @@
+{
+  "description": "set: The ServerTimestamp sentinel cannot be in an ArrayUnion",
+  "comment": "The ServerTimestamp sentinel must be the value of a field. It may\nnot appear in an ArrayUnion.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [\"ArrayRemove\", 1, \"ServerTimestamp\", 3]}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/set-arrayremove-with-st.json
+++ b/firestore/v1/testcase/set-arrayremove-with-st.json
@@ -1,9 +1,13 @@
 {
-  "description": "set: The ServerTimestamp sentinel cannot be in an ArrayUnion",
-  "comment": "The ServerTimestamp sentinel must be the value of a field. It may\nnot appear in an ArrayUnion.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [\"ArrayRemove\", 1, \"ServerTimestamp\", 3]}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "set: The ServerTimestamp sentinel cannot be in an ArrayUnion",
+      "comment": "The ServerTimestamp sentinel must be the value of a field. It may\nnot appear in an ArrayUnion.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [\"ArrayRemove\", 1, \"ServerTimestamp\", 3]}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/set-arrayremove.json
+++ b/firestore/v1/testcase/set-arrayremove.json
@@ -1,0 +1,46 @@
+{
+  "description": "set: ArrayRemove with data",
+  "comment": "A key with ArrayRemove is removed from the data in the update \noperation. Instead it appears in a separate Transform operation.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b\": [\"ArrayRemove\", 1, 2, 3]}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b",
+                "removeAllFromArray": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "integerValue": "2"
+                    },
+                    {
+                      "integerValue": "3"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/set-arrayremove.json
+++ b/firestore/v1/testcase/set-arrayremove.json
@@ -1,46 +1,50 @@
 {
-  "description": "set: ArrayRemove with data",
-  "comment": "A key with ArrayRemove is removed from the data in the update \noperation. Instead it appears in a separate Transform operation.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b\": [\"ArrayRemove\", 1, 2, 3]}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            }
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b",
-                "removeAllFromArray": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "integerValue": "2"
-                    },
-                    {
-                      "integerValue": "3"
-                    }
-                  ]
+  "tests": [
+    {
+      "description": "set: ArrayRemove with data",
+      "comment": "A key with ArrayRemove is removed from the data in the update \noperation. Instead it appears in a separate Transform operation.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b\": [\"ArrayRemove\", 1, 2, 3]}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
                 }
               }
-            ]
-          }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b",
+                    "removeAllFromArray": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "integerValue": "2"
+                        },
+                        {
+                          "integerValue": "3"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/set-arrayunion-multi.json
+++ b/firestore/v1/testcase/set-arrayunion-multi.json
@@ -1,0 +1,62 @@
+{
+  "description": "set: multiple ArrayUnion fields",
+  "comment": "A document can have more than one ArrayUnion field.\nSince all the ArrayUnion fields are removed, the only field in the update is \"a\".",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b\": [\"ArrayUnion\", 1, 2, 3], \"c\": {\"d\": [\"ArrayUnion\", 4, 5, 6]}}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b",
+                "appendMissingElements": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "integerValue": "2"
+                    },
+                    {
+                      "integerValue": "3"
+                    }
+                  ]
+                }
+              },
+              {
+                "fieldPath": "c.d",
+                "appendMissingElements": {
+                  "values": [
+                    {
+                      "integerValue": "4"
+                    },
+                    {
+                      "integerValue": "5"
+                    },
+                    {
+                      "integerValue": "6"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/set-arrayunion-multi.json
+++ b/firestore/v1/testcase/set-arrayunion-multi.json
@@ -1,62 +1,66 @@
 {
-  "description": "set: multiple ArrayUnion fields",
-  "comment": "A document can have more than one ArrayUnion field.\nSince all the ArrayUnion fields are removed, the only field in the update is \"a\".",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b\": [\"ArrayUnion\", 1, 2, 3], \"c\": {\"d\": [\"ArrayUnion\", 4, 5, 6]}}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
+  "tests": [
+    {
+      "description": "set: multiple ArrayUnion fields",
+      "comment": "A document can have more than one ArrayUnion field.\nSince all the ArrayUnion fields are removed, the only field in the update is \"a\".",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b\": [\"ArrayUnion\", 1, 2, 3], \"c\": {\"d\": [\"ArrayUnion\", 4, 5, 6]}}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b",
+                    "appendMissingElements": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "integerValue": "2"
+                        },
+                        {
+                          "integerValue": "3"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "fieldPath": "c.d",
+                    "appendMissingElements": {
+                      "values": [
+                        {
+                          "integerValue": "4"
+                        },
+                        {
+                          "integerValue": "5"
+                        },
+                        {
+                          "integerValue": "6"
+                        }
+                      ]
+                    }
+                  }
+                ]
               }
             }
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b",
-                "appendMissingElements": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "integerValue": "2"
-                    },
-                    {
-                      "integerValue": "3"
-                    }
-                  ]
-                }
-              },
-              {
-                "fieldPath": "c.d",
-                "appendMissingElements": {
-                  "values": [
-                    {
-                      "integerValue": "4"
-                    },
-                    {
-                      "integerValue": "5"
-                    },
-                    {
-                      "integerValue": "6"
-                    }
-                  ]
-                }
-              }
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/set-arrayunion-nested.json
+++ b/firestore/v1/testcase/set-arrayunion-nested.json
@@ -1,0 +1,46 @@
+{
+  "description": "set: nested ArrayUnion field",
+  "comment": "An ArrayUnion value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b\": {\"c\": [\"ArrayUnion\", 1, 2, 3]}}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b.c",
+                "appendMissingElements": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "integerValue": "2"
+                    },
+                    {
+                      "integerValue": "3"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/set-arrayunion-nested.json
+++ b/firestore/v1/testcase/set-arrayunion-nested.json
@@ -1,46 +1,50 @@
 {
-  "description": "set: nested ArrayUnion field",
-  "comment": "An ArrayUnion value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b\": {\"c\": [\"ArrayUnion\", 1, 2, 3]}}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            }
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b.c",
-                "appendMissingElements": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "integerValue": "2"
-                    },
-                    {
-                      "integerValue": "3"
-                    }
-                  ]
+  "tests": [
+    {
+      "description": "set: nested ArrayUnion field",
+      "comment": "An ArrayUnion value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b\": {\"c\": [\"ArrayUnion\", 1, 2, 3]}}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
                 }
               }
-            ]
-          }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b.c",
+                    "appendMissingElements": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "integerValue": "2"
+                        },
+                        {
+                          "integerValue": "3"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/set-arrayunion-noarray-nested.json
+++ b/firestore/v1/testcase/set-arrayunion-noarray-nested.json
@@ -1,0 +1,9 @@
+{
+  "description": "set: ArrayUnion cannot be anywhere inside an array value",
+  "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ArrayUnion. Firestore transforms don't support array indexing.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [1, {\"b\": [\"ArrayUnion\", 1, 2, 3]}]}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/set-arrayunion-noarray-nested.json
+++ b/firestore/v1/testcase/set-arrayunion-noarray-nested.json
@@ -1,9 +1,13 @@
 {
-  "description": "set: ArrayUnion cannot be anywhere inside an array value",
-  "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ArrayUnion. Firestore transforms don't support array indexing.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [1, {\"b\": [\"ArrayUnion\", 1, 2, 3]}]}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "set: ArrayUnion cannot be anywhere inside an array value",
+      "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ArrayUnion. Firestore transforms don't support array indexing.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [1, {\"b\": [\"ArrayUnion\", 1, 2, 3]}]}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/set-arrayunion-noarray.json
+++ b/firestore/v1/testcase/set-arrayunion-noarray.json
@@ -1,0 +1,9 @@
+{
+  "description": "set: ArrayUnion cannot be in an array value",
+  "comment": "ArrayUnion must be the value of a field. Firestore\ntransforms don't support array indexing.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [1, 2, [\"ArrayRemove\", 1, 2, 3]]}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/set-arrayunion-noarray.json
+++ b/firestore/v1/testcase/set-arrayunion-noarray.json
@@ -1,9 +1,13 @@
 {
-  "description": "set: ArrayUnion cannot be in an array value",
-  "comment": "ArrayUnion must be the value of a field. Firestore\ntransforms don't support array indexing.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [1, 2, [\"ArrayRemove\", 1, 2, 3]]}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "set: ArrayUnion cannot be in an array value",
+      "comment": "ArrayUnion must be the value of a field. Firestore\ntransforms don't support array indexing.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [1, 2, [\"ArrayRemove\", 1, 2, 3]]}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/set-arrayunion-with-st.json
+++ b/firestore/v1/testcase/set-arrayunion-with-st.json
@@ -1,0 +1,9 @@
+{
+  "description": "set: The ServerTimestamp sentinel cannot be in an ArrayUnion",
+  "comment": "The ServerTimestamp sentinel must be the value of a field. It may\nnot appear in an ArrayUnion.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [\"ArrayUnion\", 1, \"ServerTimestamp\", 3]}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/set-arrayunion-with-st.json
+++ b/firestore/v1/testcase/set-arrayunion-with-st.json
@@ -1,9 +1,13 @@
 {
-  "description": "set: The ServerTimestamp sentinel cannot be in an ArrayUnion",
-  "comment": "The ServerTimestamp sentinel must be the value of a field. It may\nnot appear in an ArrayUnion.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [\"ArrayUnion\", 1, \"ServerTimestamp\", 3]}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "set: The ServerTimestamp sentinel cannot be in an ArrayUnion",
+      "comment": "The ServerTimestamp sentinel must be the value of a field. It may\nnot appear in an ArrayUnion.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [\"ArrayUnion\", 1, \"ServerTimestamp\", 3]}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/set-arrayunion.json
+++ b/firestore/v1/testcase/set-arrayunion.json
@@ -1,0 +1,46 @@
+{
+  "description": "set: ArrayUnion with data",
+  "comment": "A key with ArrayUnion is removed from the data in the update \noperation. Instead it appears in a separate Transform operation.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b\": [\"ArrayUnion\", 1, 2, 3]}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b",
+                "appendMissingElements": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "integerValue": "2"
+                    },
+                    {
+                      "integerValue": "3"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/set-arrayunion.json
+++ b/firestore/v1/testcase/set-arrayunion.json
@@ -1,46 +1,50 @@
 {
-  "description": "set: ArrayUnion with data",
-  "comment": "A key with ArrayUnion is removed from the data in the update \noperation. Instead it appears in a separate Transform operation.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b\": [\"ArrayUnion\", 1, 2, 3]}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            }
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b",
-                "appendMissingElements": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "integerValue": "2"
-                    },
-                    {
-                      "integerValue": "3"
-                    }
-                  ]
+  "tests": [
+    {
+      "description": "set: ArrayUnion with data",
+      "comment": "A key with ArrayUnion is removed from the data in the update \noperation. Instead it appears in a separate Transform operation.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b\": [\"ArrayUnion\", 1, 2, 3]}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
                 }
               }
-            ]
-          }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b",
+                    "appendMissingElements": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "integerValue": "2"
+                        },
+                        {
+                          "integerValue": "3"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/set-basic.json
+++ b/firestore/v1/testcase/set-basic.json
@@ -1,0 +1,23 @@
+{
+  "description": "set: basic",
+  "comment": "A simple call, resulting in a single update operation.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/set-basic.json
+++ b/firestore/v1/testcase/set-basic.json
@@ -1,23 +1,27 @@
 {
-  "description": "set: basic",
-  "comment": "A simple call, resulting in a single update operation.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
+  "tests": [
+    {
+      "description": "set: basic",
+      "comment": "A simple call, resulting in a single update operation.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
               }
             }
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/set-complex.json
+++ b/firestore/v1/testcase/set-complex.json
@@ -1,0 +1,56 @@
+{
+  "description": "set: complex",
+  "comment": "A call to a write method with complicated input data.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [1, 2.5], \"b\": {\"c\": [\"three\", {\"d\": true}]}}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "arrayValue": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "doubleValue": 2.5
+                    }
+                  ]
+                }
+              },
+              "b": {
+                "mapValue": {
+                  "fields": {
+                    "c": {
+                      "arrayValue": {
+                        "values": [
+                          {
+                            "stringValue": "three"
+                          },
+                          {
+                            "mapValue": {
+                              "fields": {
+                                "d": {
+                                  "booleanValue": true
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/set-complex.json
+++ b/firestore/v1/testcase/set-complex.json
@@ -1,56 +1,60 @@
 {
-  "description": "set: complex",
-  "comment": "A call to a write method with complicated input data.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [1, 2.5], \"b\": {\"c\": [\"three\", {\"d\": true}]}}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "arrayValue": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "doubleValue": 2.5
+  "tests": [
+    {
+      "description": "set: complex",
+      "comment": "A call to a write method with complicated input data.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [1, 2.5], \"b\": {\"c\": [\"three\", {\"d\": true}]}}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "arrayValue": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "doubleValue": 2.5
+                        }
+                      ]
                     }
-                  ]
-                }
-              },
-              "b": {
-                "mapValue": {
-                  "fields": {
-                    "c": {
-                      "arrayValue": {
-                        "values": [
-                          {
-                            "stringValue": "three"
-                          },
-                          {
-                            "mapValue": {
-                              "fields": {
-                                "d": {
-                                  "booleanValue": true
+                  },
+                  "b": {
+                    "mapValue": {
+                      "fields": {
+                        "c": {
+                          "arrayValue": {
+                            "values": [
+                              {
+                                "stringValue": "three"
+                              },
+                              {
+                                "mapValue": {
+                                  "fields": {
+                                    "d": {
+                                      "booleanValue": true
+                                    }
+                                  }
                                 }
                               }
-                            }
+                            ]
                           }
-                        ]
+                        }
                       }
                     }
                   }
                 }
               }
             }
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/set-del-merge-alone.json
+++ b/firestore/v1/testcase/set-del-merge-alone.json
@@ -1,0 +1,33 @@
+{
+  "description": "set-merge: Delete with merge",
+  "comment": "A Delete sentinel can appear with a merge option. If the delete\npaths are the only ones to be merged, then no document is sent, just an update mask.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "option": {
+      "fields": [
+        {
+          "field": [
+            "b",
+            "c"
+          ]
+        }
+      ]
+    },
+    "jsonData": "{\"a\": 1, \"b\": {\"c\": \"Delete\"}}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d"
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "b.c"
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/set-del-merge-alone.json
+++ b/firestore/v1/testcase/set-del-merge-alone.json
@@ -1,33 +1,37 @@
 {
-  "description": "set-merge: Delete with merge",
-  "comment": "A Delete sentinel can appear with a merge option. If the delete\npaths are the only ones to be merged, then no document is sent, just an update mask.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "option": {
-      "fields": [
-        {
-          "field": [
-            "b",
-            "c"
+  "tests": [
+    {
+      "description": "set-merge: Delete with merge",
+      "comment": "A Delete sentinel can appear with a merge option. If the delete\npaths are the only ones to be merged, then no document is sent, just an update mask.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "option": {
+          "fields": [
+            {
+              "field": [
+                "b",
+                "c"
+              ]
+            }
+          ]
+        },
+        "jsonData": "{\"a\": 1, \"b\": {\"c\": \"Delete\"}}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d"
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "b.c"
+                ]
+              }
+            }
           ]
         }
-      ]
-    },
-    "jsonData": "{\"a\": 1, \"b\": {\"c\": \"Delete\"}}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d"
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "b.c"
-            ]
-          }
-        }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/set-del-merge.json
+++ b/firestore/v1/testcase/set-del-merge.json
@@ -1,0 +1,44 @@
+{
+  "description": "set-merge: Delete with merge",
+  "comment": "A Delete sentinel can appear with a merge option.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "option": {
+      "fields": [
+        {
+          "field": [
+            "a"
+          ]
+        },
+        {
+          "field": [
+            "b",
+            "c"
+          ]
+        }
+      ]
+    },
+    "jsonData": "{\"a\": 1, \"b\": {\"c\": \"Delete\"}}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a",
+              "b.c"
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/set-del-merge.json
+++ b/firestore/v1/testcase/set-del-merge.json
@@ -1,44 +1,48 @@
 {
-  "description": "set-merge: Delete with merge",
-  "comment": "A Delete sentinel can appear with a merge option.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "option": {
-      "fields": [
-        {
-          "field": [
-            "a"
+  "tests": [
+    {
+      "description": "set-merge: Delete with merge",
+      "comment": "A Delete sentinel can appear with a merge option.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "option": {
+          "fields": [
+            {
+              "field": [
+                "a"
+              ]
+            },
+            {
+              "field": [
+                "b",
+                "c"
+              ]
+            }
           ]
         },
-        {
-          "field": [
-            "b",
-            "c"
-          ]
-        }
-      ]
-    },
-    "jsonData": "{\"a\": 1, \"b\": {\"c\": \"Delete\"}}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
+        "jsonData": "{\"a\": 1, \"b\": {\"c\": \"Delete\"}}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a",
+                  "b.c"
+                ]
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "a",
-              "b.c"
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/set-del-mergeall.json
+++ b/firestore/v1/testcase/set-del-mergeall.json
@@ -1,0 +1,32 @@
+{
+  "description": "set: Delete with MergeAll",
+  "comment": "A Delete sentinel can appear with a mergeAll option.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "option": {
+      "all": true
+    },
+    "jsonData": "{\"a\": 1, \"b\": {\"c\": \"Delete\"}}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a",
+              "b.c"
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/set-del-mergeall.json
+++ b/firestore/v1/testcase/set-del-mergeall.json
@@ -1,32 +1,36 @@
 {
-  "description": "set: Delete with MergeAll",
-  "comment": "A Delete sentinel can appear with a mergeAll option.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "option": {
-      "all": true
-    },
-    "jsonData": "{\"a\": 1, \"b\": {\"c\": \"Delete\"}}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
+  "tests": [
+    {
+      "description": "set: Delete with MergeAll",
+      "comment": "A Delete sentinel can appear with a mergeAll option.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "option": {
+          "all": true
+        },
+        "jsonData": "{\"a\": 1, \"b\": {\"c\": \"Delete\"}}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a",
+                  "b.c"
+                ]
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "a",
-              "b.c"
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/set-del-noarray-nested.json
+++ b/firestore/v1/testcase/set-del-noarray-nested.json
@@ -1,0 +1,9 @@
+{
+  "description": "set: Delete cannot be anywhere inside an array value",
+  "comment": "The Delete sentinel must be the value of a field. Deletes are implemented\nby turning the path to the Delete sentinel into a FieldPath, and FieldPaths do not support\narray indexing.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [1, {\"b\": \"Delete\"}]}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/set-del-noarray-nested.json
+++ b/firestore/v1/testcase/set-del-noarray-nested.json
@@ -1,9 +1,13 @@
 {
-  "description": "set: Delete cannot be anywhere inside an array value",
-  "comment": "The Delete sentinel must be the value of a field. Deletes are implemented\nby turning the path to the Delete sentinel into a FieldPath, and FieldPaths do not support\narray indexing.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [1, {\"b\": \"Delete\"}]}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "set: Delete cannot be anywhere inside an array value",
+      "comment": "The Delete sentinel must be the value of a field. Deletes are implemented\nby turning the path to the Delete sentinel into a FieldPath, and FieldPaths do not support\narray indexing.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [1, {\"b\": \"Delete\"}]}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/set-del-noarray.json
+++ b/firestore/v1/testcase/set-del-noarray.json
@@ -1,0 +1,9 @@
+{
+  "description": "set: Delete cannot be in an array value",
+  "comment": "The Delete sentinel must be the value of a field. Deletes are\nimplemented by turning the path to the Delete sentinel into a FieldPath, and FieldPaths\ndo not support array indexing.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [1, 2, \"Delete\"]}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/set-del-noarray.json
+++ b/firestore/v1/testcase/set-del-noarray.json
@@ -1,9 +1,13 @@
 {
-  "description": "set: Delete cannot be in an array value",
-  "comment": "The Delete sentinel must be the value of a field. Deletes are\nimplemented by turning the path to the Delete sentinel into a FieldPath, and FieldPaths\ndo not support array indexing.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [1, 2, \"Delete\"]}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "set: Delete cannot be in an array value",
+      "comment": "The Delete sentinel must be the value of a field. Deletes are\nimplemented by turning the path to the Delete sentinel into a FieldPath, and FieldPaths\ndo not support array indexing.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [1, 2, \"Delete\"]}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/set-del-nomerge.json
+++ b/firestore/v1/testcase/set-del-nomerge.json
@@ -1,0 +1,18 @@
+{
+  "description": "set-merge: Delete cannot appear in an unmerged field",
+  "comment": "The client signals an error if the Delete sentinel is in the\ninput data, but not selected by a merge option, because this is most likely a programming\nbug.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "option": {
+      "fields": [
+        {
+          "field": [
+            "a"
+          ]
+        }
+      ]
+    },
+    "jsonData": "{\"a\": 1, \"b\": \"Delete\"}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/set-del-nomerge.json
+++ b/firestore/v1/testcase/set-del-nomerge.json
@@ -1,18 +1,22 @@
 {
-  "description": "set-merge: Delete cannot appear in an unmerged field",
-  "comment": "The client signals an error if the Delete sentinel is in the\ninput data, but not selected by a merge option, because this is most likely a programming\nbug.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "option": {
-      "fields": [
-        {
-          "field": [
-            "a"
+  "tests": [
+    {
+      "description": "set-merge: Delete cannot appear in an unmerged field",
+      "comment": "The client signals an error if the Delete sentinel is in the\ninput data, but not selected by a merge option, because this is most likely a programming\nbug.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "option": {
+          "fields": [
+            {
+              "field": [
+                "a"
+              ]
+            }
           ]
-        }
-      ]
-    },
-    "jsonData": "{\"a\": 1, \"b\": \"Delete\"}",
-    "isError": true
-  }
+        },
+        "jsonData": "{\"a\": 1, \"b\": \"Delete\"}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/set-del-nonleaf.json
+++ b/firestore/v1/testcase/set-del-nonleaf.json
@@ -1,0 +1,18 @@
+{
+  "description": "set-merge: Delete cannot appear as part of a merge path",
+  "comment": "If a Delete is part of the value at a merge path, then the user is\nconfused: their merge path says \"replace this entire value\" but their Delete says\n\"delete this part of the value\". This should be an error, just as if they specified Delete\nin a Set with no merge.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "option": {
+      "fields": [
+        {
+          "field": [
+            "h"
+          ]
+        }
+      ]
+    },
+    "jsonData": "{\"h\": {\"g\": \"Delete\"}}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/set-del-nonleaf.json
+++ b/firestore/v1/testcase/set-del-nonleaf.json
@@ -1,18 +1,22 @@
 {
-  "description": "set-merge: Delete cannot appear as part of a merge path",
-  "comment": "If a Delete is part of the value at a merge path, then the user is\nconfused: their merge path says \"replace this entire value\" but their Delete says\n\"delete this part of the value\". This should be an error, just as if they specified Delete\nin a Set with no merge.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "option": {
-      "fields": [
-        {
-          "field": [
-            "h"
+  "tests": [
+    {
+      "description": "set-merge: Delete cannot appear as part of a merge path",
+      "comment": "If a Delete is part of the value at a merge path, then the user is\nconfused: their merge path says \"replace this entire value\" but their Delete says\n\"delete this part of the value\". This should be an error, just as if they specified Delete\nin a Set with no merge.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "option": {
+          "fields": [
+            {
+              "field": [
+                "h"
+              ]
+            }
           ]
-        }
-      ]
-    },
-    "jsonData": "{\"h\": {\"g\": \"Delete\"}}",
-    "isError": true
-  }
+        },
+        "jsonData": "{\"h\": {\"g\": \"Delete\"}}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/set-del-wo-merge.json
+++ b/firestore/v1/testcase/set-del-wo-merge.json
@@ -1,0 +1,9 @@
+{
+  "description": "set: Delete cannot appear unless a merge option is specified",
+  "comment": "Without a merge option, Set replaces the document with the input\ndata. A Delete sentinel in the data makes no sense in this case.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b\": \"Delete\"}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/set-del-wo-merge.json
+++ b/firestore/v1/testcase/set-del-wo-merge.json
@@ -1,9 +1,13 @@
 {
-  "description": "set: Delete cannot appear unless a merge option is specified",
-  "comment": "Without a merge option, Set replaces the document with the input\ndata. A Delete sentinel in the data makes no sense in this case.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b\": \"Delete\"}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "set: Delete cannot appear unless a merge option is specified",
+      "comment": "Without a merge option, Set replaces the document with the input\ndata. A Delete sentinel in the data makes no sense in this case.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b\": \"Delete\"}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/set-empty.json
+++ b/firestore/v1/testcase/set-empty.json
@@ -1,0 +1,18 @@
+{
+  "description": "set: creating or setting an empty map",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {}
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/set-empty.json
+++ b/firestore/v1/testcase/set-empty.json
@@ -1,18 +1,22 @@
 {
-  "description": "set: creating or setting an empty map",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {}
-          }
+  "tests": [
+    {
+      "description": "set: creating or setting an empty map",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {}
+              }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/set-merge-fp.json
+++ b/firestore/v1/testcase/set-merge-fp.json
@@ -1,0 +1,44 @@
+{
+  "description": "set-merge: Merge with FieldPaths",
+  "comment": "A merge with fields that use special characters.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "option": {
+      "fields": [
+        {
+          "field": [
+            "*",
+            "~"
+          ]
+        }
+      ]
+    },
+    "jsonData": "{\"*\": {\"~\": true}}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "*": {
+                "mapValue": {
+                  "fields": {
+                    "~": {
+                      "booleanValue": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "`*`.`~`"
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/set-merge-fp.json
+++ b/firestore/v1/testcase/set-merge-fp.json
@@ -1,44 +1,48 @@
 {
-  "description": "set-merge: Merge with FieldPaths",
-  "comment": "A merge with fields that use special characters.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "option": {
-      "fields": [
-        {
-          "field": [
-            "*",
-            "~"
+  "tests": [
+    {
+      "description": "set-merge: Merge with FieldPaths",
+      "comment": "A merge with fields that use special characters.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "option": {
+          "fields": [
+            {
+              "field": [
+                "*",
+                "~"
+              ]
+            }
           ]
-        }
-      ]
-    },
-    "jsonData": "{\"*\": {\"~\": true}}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "*": {
-                "mapValue": {
-                  "fields": {
-                    "~": {
-                      "booleanValue": true
+        },
+        "jsonData": "{\"*\": {\"~\": true}}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "*": {
+                    "mapValue": {
+                      "fields": {
+                        "~": {
+                          "booleanValue": true
+                        }
+                      }
                     }
                   }
                 }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "`*`.`~`"
+                ]
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "`*`.`~`"
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/set-merge-nested.json
+++ b/firestore/v1/testcase/set-merge-nested.json
@@ -1,0 +1,44 @@
+{
+  "description": "set-merge: Merge with a nested field",
+  "comment": "A merge option where the field is not at top level.\nOnly fields mentioned in the option are present in the update operation.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "option": {
+      "fields": [
+        {
+          "field": [
+            "h",
+            "g"
+          ]
+        }
+      ]
+    },
+    "jsonData": "{\"h\": {\"g\": 4, \"f\": 5}}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "h": {
+                "mapValue": {
+                  "fields": {
+                    "g": {
+                      "integerValue": "4"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "h.g"
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/set-merge-nested.json
+++ b/firestore/v1/testcase/set-merge-nested.json
@@ -1,44 +1,48 @@
 {
-  "description": "set-merge: Merge with a nested field",
-  "comment": "A merge option where the field is not at top level.\nOnly fields mentioned in the option are present in the update operation.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "option": {
-      "fields": [
-        {
-          "field": [
-            "h",
-            "g"
+  "tests": [
+    {
+      "description": "set-merge: Merge with a nested field",
+      "comment": "A merge option where the field is not at top level.\nOnly fields mentioned in the option are present in the update operation.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "option": {
+          "fields": [
+            {
+              "field": [
+                "h",
+                "g"
+              ]
+            }
           ]
-        }
-      ]
-    },
-    "jsonData": "{\"h\": {\"g\": 4, \"f\": 5}}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "h": {
-                "mapValue": {
-                  "fields": {
-                    "g": {
-                      "integerValue": "4"
+        },
+        "jsonData": "{\"h\": {\"g\": 4, \"f\": 5}}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "h": {
+                    "mapValue": {
+                      "fields": {
+                        "g": {
+                          "integerValue": "4"
+                        }
+                      }
                     }
                   }
                 }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "h.g"
+                ]
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "h.g"
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/set-merge-nonleaf.json
+++ b/firestore/v1/testcase/set-merge-nonleaf.json
@@ -1,0 +1,46 @@
+{
+  "description": "set-merge: Merge field is not a leaf",
+  "comment": "If a field path is in a merge option, the value at that path\nreplaces the stored value. That is true even if the value is complex.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "option": {
+      "fields": [
+        {
+          "field": [
+            "h"
+          ]
+        }
+      ]
+    },
+    "jsonData": "{\"h\": {\"f\": 5, \"g\": 6}, \"e\": 7}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "h": {
+                "mapValue": {
+                  "fields": {
+                    "f": {
+                      "integerValue": "5"
+                    },
+                    "g": {
+                      "integerValue": "6"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "h"
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/set-merge-nonleaf.json
+++ b/firestore/v1/testcase/set-merge-nonleaf.json
@@ -1,46 +1,50 @@
 {
-  "description": "set-merge: Merge field is not a leaf",
-  "comment": "If a field path is in a merge option, the value at that path\nreplaces the stored value. That is true even if the value is complex.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "option": {
-      "fields": [
-        {
-          "field": [
-            "h"
+  "tests": [
+    {
+      "description": "set-merge: Merge field is not a leaf",
+      "comment": "If a field path is in a merge option, the value at that path\nreplaces the stored value. That is true even if the value is complex.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "option": {
+          "fields": [
+            {
+              "field": [
+                "h"
+              ]
+            }
           ]
-        }
-      ]
-    },
-    "jsonData": "{\"h\": {\"f\": 5, \"g\": 6}, \"e\": 7}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "h": {
-                "mapValue": {
-                  "fields": {
-                    "f": {
-                      "integerValue": "5"
-                    },
-                    "g": {
-                      "integerValue": "6"
+        },
+        "jsonData": "{\"h\": {\"f\": 5, \"g\": 6}, \"e\": 7}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "h": {
+                    "mapValue": {
+                      "fields": {
+                        "f": {
+                          "integerValue": "5"
+                        },
+                        "g": {
+                          "integerValue": "6"
+                        }
+                      }
                     }
                   }
                 }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "h"
+                ]
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "h"
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/set-merge-prefix.json
+++ b/firestore/v1/testcase/set-merge-prefix.json
@@ -1,0 +1,24 @@
+{
+  "description": "set-merge: One merge path cannot be the prefix of another",
+  "comment": "The prefix would make the other path meaningless, so this is\nprobably a programming error.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "option": {
+      "fields": [
+        {
+          "field": [
+            "a"
+          ]
+        },
+        {
+          "field": [
+            "a",
+            "b"
+          ]
+        }
+      ]
+    },
+    "jsonData": "{\"a\": {\"b\": 1}}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/set-merge-prefix.json
+++ b/firestore/v1/testcase/set-merge-prefix.json
@@ -1,24 +1,28 @@
 {
-  "description": "set-merge: One merge path cannot be the prefix of another",
-  "comment": "The prefix would make the other path meaningless, so this is\nprobably a programming error.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "option": {
-      "fields": [
-        {
-          "field": [
-            "a"
+  "tests": [
+    {
+      "description": "set-merge: One merge path cannot be the prefix of another",
+      "comment": "The prefix would make the other path meaningless, so this is\nprobably a programming error.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "option": {
+          "fields": [
+            {
+              "field": [
+                "a"
+              ]
+            },
+            {
+              "field": [
+                "a",
+                "b"
+              ]
+            }
           ]
         },
-        {
-          "field": [
-            "a",
-            "b"
-          ]
-        }
-      ]
-    },
-    "jsonData": "{\"a\": {\"b\": 1}}",
-    "isError": true
-  }
+        "jsonData": "{\"a\": {\"b\": 1}}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/set-merge-present.json
+++ b/firestore/v1/testcase/set-merge-present.json
@@ -1,0 +1,23 @@
+{
+  "description": "set-merge: Merge fields must all be present in data",
+  "comment": "The client signals an error if a merge option mentions a path\nthat is not in the input data.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "option": {
+      "fields": [
+        {
+          "field": [
+            "b"
+          ]
+        },
+        {
+          "field": [
+            "a"
+          ]
+        }
+      ]
+    },
+    "jsonData": "{\"a\": 1}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/set-merge-present.json
+++ b/firestore/v1/testcase/set-merge-present.json
@@ -1,23 +1,27 @@
 {
-  "description": "set-merge: Merge fields must all be present in data",
-  "comment": "The client signals an error if a merge option mentions a path\nthat is not in the input data.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "option": {
-      "fields": [
-        {
-          "field": [
-            "b"
+  "tests": [
+    {
+      "description": "set-merge: Merge fields must all be present in data",
+      "comment": "The client signals an error if a merge option mentions a path\nthat is not in the input data.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "option": {
+          "fields": [
+            {
+              "field": [
+                "b"
+              ]
+            },
+            {
+              "field": [
+                "a"
+              ]
+            }
           ]
         },
-        {
-          "field": [
-            "a"
-          ]
-        }
-      ]
-    },
-    "jsonData": "{\"a\": 1}",
-    "isError": true
-  }
+        "jsonData": "{\"a\": 1}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/set-merge.json
+++ b/firestore/v1/testcase/set-merge.json
@@ -1,0 +1,37 @@
+{
+  "description": "set-merge: Merge with a field",
+  "comment": "Fields in the input data but not in a merge option are pruned.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "option": {
+      "fields": [
+        {
+          "field": [
+            "a"
+          ]
+        }
+      ]
+    },
+    "jsonData": "{\"a\": 1, \"b\": 2}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a"
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/set-merge.json
+++ b/firestore/v1/testcase/set-merge.json
@@ -1,37 +1,41 @@
 {
-  "description": "set-merge: Merge with a field",
-  "comment": "Fields in the input data but not in a merge option are pruned.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "option": {
-      "fields": [
-        {
-          "field": [
-            "a"
+  "tests": [
+    {
+      "description": "set-merge: Merge with a field",
+      "comment": "Fields in the input data but not in a merge option are pruned.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "option": {
+          "fields": [
+            {
+              "field": [
+                "a"
+              ]
+            }
           ]
-        }
-      ]
-    },
-    "jsonData": "{\"a\": 1, \"b\": 2}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
+        },
+        "jsonData": "{\"a\": 1, \"b\": 2}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a"
+                ]
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "a"
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/set-mergeall-empty.json
+++ b/firestore/v1/testcase/set-mergeall-empty.json
@@ -1,0 +1,25 @@
+{
+  "description": "set: MergeAll can be specified with empty data.",
+  "comment": "This is a valid call that can be used to ensure a document exists.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "option": {
+      "all": true
+    },
+    "jsonData": "{}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {}
+          },
+          "updateMask": {
+            "fieldPaths": []
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/set-mergeall-empty.json
+++ b/firestore/v1/testcase/set-mergeall-empty.json
@@ -1,25 +1,29 @@
 {
-  "description": "set: MergeAll can be specified with empty data.",
-  "comment": "This is a valid call that can be used to ensure a document exists.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "option": {
-      "all": true
-    },
-    "jsonData": "{}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {}
-          },
-          "updateMask": {
-            "fieldPaths": []
-          }
+  "tests": [
+    {
+      "description": "set: MergeAll can be specified with empty data.",
+      "comment": "This is a valid call that can be used to ensure a document exists.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "option": {
+          "all": true
+        },
+        "jsonData": "{}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {}
+              },
+              "updateMask": {
+                "fieldPaths": []
+              }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/set-mergeall-nested.json
+++ b/firestore/v1/testcase/set-mergeall-nested.json
@@ -1,0 +1,41 @@
+{
+  "description": "set: MergeAll with nested fields",
+  "comment": "MergeAll with nested fields results in an update mask that\nincludes entries for all the leaf fields.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "option": {
+      "all": true
+    },
+    "jsonData": "{\"h\": { \"g\": 3, \"f\": 4 }}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "h": {
+                "mapValue": {
+                  "fields": {
+                    "f": {
+                      "integerValue": "4"
+                    },
+                    "g": {
+                      "integerValue": "3"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "h.f",
+              "h.g"
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/set-mergeall-nested.json
+++ b/firestore/v1/testcase/set-mergeall-nested.json
@@ -1,41 +1,45 @@
 {
-  "description": "set: MergeAll with nested fields",
-  "comment": "MergeAll with nested fields results in an update mask that\nincludes entries for all the leaf fields.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "option": {
-      "all": true
-    },
-    "jsonData": "{\"h\": { \"g\": 3, \"f\": 4 }}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "h": {
-                "mapValue": {
-                  "fields": {
-                    "f": {
-                      "integerValue": "4"
-                    },
-                    "g": {
-                      "integerValue": "3"
+  "tests": [
+    {
+      "description": "set: MergeAll with nested fields",
+      "comment": "MergeAll with nested fields results in an update mask that\nincludes entries for all the leaf fields.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "option": {
+          "all": true
+        },
+        "jsonData": "{\"h\": { \"g\": 3, \"f\": 4 }}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "h": {
+                    "mapValue": {
+                      "fields": {
+                        "f": {
+                          "integerValue": "4"
+                        },
+                        "g": {
+                          "integerValue": "3"
+                        }
+                      }
                     }
                   }
                 }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "h.f",
+                  "h.g"
+                ]
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "h.f",
-              "h.g"
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/set-mergeall.json
+++ b/firestore/v1/testcase/set-mergeall.json
@@ -1,0 +1,35 @@
+{
+  "description": "set: MergeAll",
+  "comment": "The MergeAll option with a simple piece of data.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "option": {
+      "all": true
+    },
+    "jsonData": "{\"a\": 1, \"b\": 2}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              },
+              "b": {
+                "integerValue": "2"
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a",
+              "b"
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/set-mergeall.json
+++ b/firestore/v1/testcase/set-mergeall.json
@@ -1,35 +1,39 @@
 {
-  "description": "set: MergeAll",
-  "comment": "The MergeAll option with a simple piece of data.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "option": {
-      "all": true
-    },
-    "jsonData": "{\"a\": 1, \"b\": 2}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
+  "tests": [
+    {
+      "description": "set: MergeAll",
+      "comment": "The MergeAll option with a simple piece of data.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "option": {
+          "all": true
+        },
+        "jsonData": "{\"a\": 1, \"b\": 2}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  },
+                  "b": {
+                    "integerValue": "2"
+                  }
+                }
               },
-              "b": {
-                "integerValue": "2"
+              "updateMask": {
+                "fieldPaths": [
+                  "a",
+                  "b"
+                ]
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "a",
-              "b"
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/set-nodel.json
+++ b/firestore/v1/testcase/set-nodel.json
@@ -1,0 +1,9 @@
+{
+  "description": "set: Delete cannot appear in data",
+  "comment": "The Delete sentinel cannot be used in Create, or in Set without a Merge option.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b\": \"Delete\"}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/set-nodel.json
+++ b/firestore/v1/testcase/set-nodel.json
@@ -1,9 +1,13 @@
 {
-  "description": "set: Delete cannot appear in data",
-  "comment": "The Delete sentinel cannot be used in Create, or in Set without a Merge option.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b\": \"Delete\"}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "set: Delete cannot appear in data",
+      "comment": "The Delete sentinel cannot be used in Create, or in Set without a Merge option.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b\": \"Delete\"}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/set-nosplit.json
+++ b/firestore/v1/testcase/set-nosplit.json
@@ -1,0 +1,32 @@
+{
+  "description": "set: don’t split on dots",
+  "comment": "Create and Set treat their map keys literally. They do not split on dots.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{ \"a.b\": { \"c.d\": 1 }, \"e\": 2 }",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a.b": {
+                "mapValue": {
+                  "fields": {
+                    "c.d": {
+                      "integerValue": "1"
+                    }
+                  }
+                }
+              },
+              "e": {
+                "integerValue": "2"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/set-nosplit.json
+++ b/firestore/v1/testcase/set-nosplit.json
@@ -1,32 +1,36 @@
 {
-  "description": "set: don’t split on dots",
-  "comment": "Create and Set treat their map keys literally. They do not split on dots.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{ \"a.b\": { \"c.d\": 1 }, \"e\": 2 }",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a.b": {
-                "mapValue": {
-                  "fields": {
-                    "c.d": {
-                      "integerValue": "1"
+  "tests": [
+    {
+      "description": "set: don’t split on dots",
+      "comment": "Create and Set treat their map keys literally. They do not split on dots.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{ \"a.b\": { \"c.d\": 1 }, \"e\": 2 }",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a.b": {
+                    "mapValue": {
+                      "fields": {
+                        "c.d": {
+                          "integerValue": "1"
+                        }
+                      }
                     }
+                  },
+                  "e": {
+                    "integerValue": "2"
                   }
                 }
-              },
-              "e": {
-                "integerValue": "2"
               }
             }
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/set-special-chars.json
+++ b/firestore/v1/testcase/set-special-chars.json
@@ -1,0 +1,32 @@
+{
+  "description": "set: non-alpha characters in map keys",
+  "comment": "Create and Set treat their map keys literally. They do not escape special characters.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{ \"*\": { \".\": 1 }, \"~\": 2 }",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "*": {
+                "mapValue": {
+                  "fields": {
+                    ".": {
+                      "integerValue": "1"
+                    }
+                  }
+                }
+              },
+              "~": {
+                "integerValue": "2"
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/set-special-chars.json
+++ b/firestore/v1/testcase/set-special-chars.json
@@ -1,32 +1,36 @@
 {
-  "description": "set: non-alpha characters in map keys",
-  "comment": "Create and Set treat their map keys literally. They do not escape special characters.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{ \"*\": { \".\": 1 }, \"~\": 2 }",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "*": {
-                "mapValue": {
-                  "fields": {
-                    ".": {
-                      "integerValue": "1"
+  "tests": [
+    {
+      "description": "set: non-alpha characters in map keys",
+      "comment": "Create and Set treat their map keys literally. They do not escape special characters.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{ \"*\": { \".\": 1 }, \"~\": 2 }",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "*": {
+                    "mapValue": {
+                      "fields": {
+                        ".": {
+                          "integerValue": "1"
+                        }
+                      }
                     }
+                  },
+                  "~": {
+                    "integerValue": "2"
                   }
                 }
-              },
-              "~": {
-                "integerValue": "2"
               }
             }
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/set-st-alone-mergeall.json
+++ b/firestore/v1/testcase/set-st-alone-mergeall.json
@@ -1,0 +1,27 @@
+{
+  "description": "set: ServerTimestamp alone with MergeAll",
+  "comment": "If the only values in the input are ServerTimestamps, then no\nupdate operation should be produced.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "option": {
+      "all": true
+    },
+    "jsonData": "{\"a\": \"ServerTimestamp\"}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "a",
+                "setToServerValue": "REQUEST_TIME"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/set-st-alone-mergeall.json
+++ b/firestore/v1/testcase/set-st-alone-mergeall.json
@@ -1,27 +1,31 @@
 {
-  "description": "set: ServerTimestamp alone with MergeAll",
-  "comment": "If the only values in the input are ServerTimestamps, then no\nupdate operation should be produced.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "option": {
-      "all": true
-    },
-    "jsonData": "{\"a\": \"ServerTimestamp\"}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "a",
-                "setToServerValue": "REQUEST_TIME"
+  "tests": [
+    {
+      "description": "set: ServerTimestamp alone with MergeAll",
+      "comment": "If the only values in the input are ServerTimestamps, then no\nupdate operation should be produced.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "option": {
+          "all": true
+        },
+        "jsonData": "{\"a\": \"ServerTimestamp\"}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "a",
+                    "setToServerValue": "REQUEST_TIME"
+                  }
+                ]
               }
-            ]
-          }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/set-st-alone.json
+++ b/firestore/v1/testcase/set-st-alone.json
@@ -1,0 +1,30 @@
+{
+  "description": "set: ServerTimestamp alone",
+  "comment": "If the only values in the input are ServerTimestamps, then\nan update operation with an empty map should be produced.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": \"ServerTimestamp\"}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {}
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "a",
+                "setToServerValue": "REQUEST_TIME"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/set-st-alone.json
+++ b/firestore/v1/testcase/set-st-alone.json
@@ -1,30 +1,34 @@
 {
-  "description": "set: ServerTimestamp alone",
-  "comment": "If the only values in the input are ServerTimestamps, then\nan update operation with an empty map should be produced.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": \"ServerTimestamp\"}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {}
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "a",
-                "setToServerValue": "REQUEST_TIME"
+  "tests": [
+    {
+      "description": "set: ServerTimestamp alone",
+      "comment": "If the only values in the input are ServerTimestamps, then\nan update operation with an empty map should be produced.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": \"ServerTimestamp\"}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {}
               }
-            ]
-          }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "a",
+                    "setToServerValue": "REQUEST_TIME"
+                  }
+                ]
+              }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/set-st-merge-both.json
+++ b/firestore/v1/testcase/set-st-merge-both.json
@@ -1,0 +1,53 @@
+{
+  "description": "set-merge: ServerTimestamp with Merge of both fields",
+  "comment": "Just as when no merge option is specified, ServerTimestamp\nsentinel values are removed from the data in the update operation and become\ntransforms.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "option": {
+      "fields": [
+        {
+          "field": [
+            "a"
+          ]
+        },
+        {
+          "field": [
+            "b"
+          ]
+        }
+      ]
+    },
+    "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\"}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a"
+            ]
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b",
+                "setToServerValue": "REQUEST_TIME"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/set-st-merge-both.json
+++ b/firestore/v1/testcase/set-st-merge-both.json
@@ -1,53 +1,57 @@
 {
-  "description": "set-merge: ServerTimestamp with Merge of both fields",
-  "comment": "Just as when no merge option is specified, ServerTimestamp\nsentinel values are removed from the data in the update operation and become\ntransforms.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "option": {
-      "fields": [
-        {
-          "field": [
-            "a"
+  "tests": [
+    {
+      "description": "set-merge: ServerTimestamp with Merge of both fields",
+      "comment": "Just as when no merge option is specified, ServerTimestamp\nsentinel values are removed from the data in the update operation and become\ntransforms.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "option": {
+          "fields": [
+            {
+              "field": [
+                "a"
+              ]
+            },
+            {
+              "field": [
+                "b"
+              ]
+            }
           ]
         },
-        {
-          "field": [
-            "b"
-          ]
-        }
-      ]
-    },
-    "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\"}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
+        "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\"}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a"
+                ]
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b",
+                    "setToServerValue": "REQUEST_TIME"
+                  }
+                ]
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "a"
-            ]
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b",
-                "setToServerValue": "REQUEST_TIME"
-              }
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/set-st-merge-nonleaf-alone.json
+++ b/firestore/v1/testcase/set-st-merge-nonleaf-alone.json
@@ -1,0 +1,43 @@
+{
+  "description": "set-merge: non-leaf merge field with ServerTimestamp alone",
+  "comment": "If a field path is in a merge option, the value at that path\nreplaces the stored value. If the value has only ServerTimestamps, they become transforms\nand we clear the value by including the field path in the update mask.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "option": {
+      "fields": [
+        {
+          "field": [
+            "h"
+          ]
+        }
+      ]
+    },
+    "jsonData": "{\"h\": {\"g\": \"ServerTimestamp\"}, \"e\": 7}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d"
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "h"
+            ]
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "h.g",
+                "setToServerValue": "REQUEST_TIME"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/set-st-merge-nonleaf-alone.json
+++ b/firestore/v1/testcase/set-st-merge-nonleaf-alone.json
@@ -1,43 +1,47 @@
 {
-  "description": "set-merge: non-leaf merge field with ServerTimestamp alone",
-  "comment": "If a field path is in a merge option, the value at that path\nreplaces the stored value. If the value has only ServerTimestamps, they become transforms\nand we clear the value by including the field path in the update mask.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "option": {
-      "fields": [
-        {
-          "field": [
-            "h"
+  "tests": [
+    {
+      "description": "set-merge: non-leaf merge field with ServerTimestamp alone",
+      "comment": "If a field path is in a merge option, the value at that path\nreplaces the stored value. If the value has only ServerTimestamps, they become transforms\nand we clear the value by including the field path in the update mask.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "option": {
+          "fields": [
+            {
+              "field": [
+                "h"
+              ]
+            }
+          ]
+        },
+        "jsonData": "{\"h\": {\"g\": \"ServerTimestamp\"}, \"e\": 7}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d"
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "h"
+                ]
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "h.g",
+                    "setToServerValue": "REQUEST_TIME"
+                  }
+                ]
+              }
+            }
           ]
         }
-      ]
-    },
-    "jsonData": "{\"h\": {\"g\": \"ServerTimestamp\"}, \"e\": 7}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d"
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "h"
-            ]
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "h.g",
-                "setToServerValue": "REQUEST_TIME"
-              }
-            ]
-          }
-        }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/set-st-merge-nonleaf.json
+++ b/firestore/v1/testcase/set-st-merge-nonleaf.json
@@ -1,0 +1,54 @@
+{
+  "description": "set-merge: non-leaf merge field with ServerTimestamp",
+  "comment": "If a field path is in a merge option, the value at that path\nreplaces the stored value, and ServerTimestamps inside that value become transforms\nas usual.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "option": {
+      "fields": [
+        {
+          "field": [
+            "h"
+          ]
+        }
+      ]
+    },
+    "jsonData": "{\"h\": {\"f\": 5, \"g\": \"ServerTimestamp\"}, \"e\": 7}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "h": {
+                "mapValue": {
+                  "fields": {
+                    "f": {
+                      "integerValue": "5"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "h"
+            ]
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "h.g",
+                "setToServerValue": "REQUEST_TIME"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/set-st-merge-nonleaf.json
+++ b/firestore/v1/testcase/set-st-merge-nonleaf.json
@@ -1,54 +1,58 @@
 {
-  "description": "set-merge: non-leaf merge field with ServerTimestamp",
-  "comment": "If a field path is in a merge option, the value at that path\nreplaces the stored value, and ServerTimestamps inside that value become transforms\nas usual.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "option": {
-      "fields": [
-        {
-          "field": [
-            "h"
+  "tests": [
+    {
+      "description": "set-merge: non-leaf merge field with ServerTimestamp",
+      "comment": "If a field path is in a merge option, the value at that path\nreplaces the stored value, and ServerTimestamps inside that value become transforms\nas usual.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "option": {
+          "fields": [
+            {
+              "field": [
+                "h"
+              ]
+            }
           ]
-        }
-      ]
-    },
-    "jsonData": "{\"h\": {\"f\": 5, \"g\": \"ServerTimestamp\"}, \"e\": 7}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "h": {
-                "mapValue": {
-                  "fields": {
-                    "f": {
-                      "integerValue": "5"
+        },
+        "jsonData": "{\"h\": {\"f\": 5, \"g\": \"ServerTimestamp\"}, \"e\": 7}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "h": {
+                    "mapValue": {
+                      "fields": {
+                        "f": {
+                          "integerValue": "5"
+                        }
+                      }
                     }
                   }
                 }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "h"
+                ]
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "h.g",
+                    "setToServerValue": "REQUEST_TIME"
+                  }
+                ]
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "h"
-            ]
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "h.g",
-                "setToServerValue": "REQUEST_TIME"
-              }
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/set-st-merge-nowrite.json
+++ b/firestore/v1/testcase/set-st-merge-nowrite.json
@@ -1,0 +1,33 @@
+{
+  "description": "set-merge: If no ordinary values in Merge, no write",
+  "comment": "If all the fields in the merge option have ServerTimestamp\nvalues, then no update operation is produced, only a transform.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "option": {
+      "fields": [
+        {
+          "field": [
+            "b"
+          ]
+        }
+      ]
+    },
+    "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\"}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b",
+                "setToServerValue": "REQUEST_TIME"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/set-st-merge-nowrite.json
+++ b/firestore/v1/testcase/set-st-merge-nowrite.json
@@ -1,33 +1,37 @@
 {
-  "description": "set-merge: If no ordinary values in Merge, no write",
-  "comment": "If all the fields in the merge option have ServerTimestamp\nvalues, then no update operation is produced, only a transform.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "option": {
-      "fields": [
-        {
-          "field": [
-            "b"
+  "tests": [
+    {
+      "description": "set-merge: If no ordinary values in Merge, no write",
+      "comment": "If all the fields in the merge option have ServerTimestamp\nvalues, then no update operation is produced, only a transform.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "option": {
+          "fields": [
+            {
+              "field": [
+                "b"
+              ]
+            }
+          ]
+        },
+        "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\"}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b",
+                    "setToServerValue": "REQUEST_TIME"
+                  }
+                ]
+              }
+            }
           ]
         }
-      ]
-    },
-    "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\"}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b",
-                "setToServerValue": "REQUEST_TIME"
-              }
-            ]
-          }
-        }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/set-st-mergeall.json
+++ b/firestore/v1/testcase/set-st-mergeall.json
@@ -1,0 +1,42 @@
+{
+  "description": "set: ServerTimestamp with MergeAll",
+  "comment": "Just as when no merge option is specified, ServerTimestamp\nsentinel values are removed from the data in the update operation and become\ntransforms.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "option": {
+      "all": true
+    },
+    "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\"}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a"
+            ]
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b",
+                "setToServerValue": "REQUEST_TIME"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/set-st-mergeall.json
+++ b/firestore/v1/testcase/set-st-mergeall.json
@@ -1,42 +1,46 @@
 {
-  "description": "set: ServerTimestamp with MergeAll",
-  "comment": "Just as when no merge option is specified, ServerTimestamp\nsentinel values are removed from the data in the update operation and become\ntransforms.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "option": {
-      "all": true
-    },
-    "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\"}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
+  "tests": [
+    {
+      "description": "set: ServerTimestamp with MergeAll",
+      "comment": "Just as when no merge option is specified, ServerTimestamp\nsentinel values are removed from the data in the update operation and become\ntransforms.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "option": {
+          "all": true
+        },
+        "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\"}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a"
+                ]
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b",
+                    "setToServerValue": "REQUEST_TIME"
+                  }
+                ]
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "a"
-            ]
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b",
-                "setToServerValue": "REQUEST_TIME"
-              }
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/set-st-multi.json
+++ b/firestore/v1/testcase/set-st-multi.json
@@ -1,0 +1,38 @@
+{
+  "description": "set: multiple ServerTimestamp fields",
+  "comment": "A document can have more than one ServerTimestamp field.\nSince all the ServerTimestamp fields are removed, the only field in the update is \"a\".",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\", \"c\": {\"d\": \"ServerTimestamp\"}}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b",
+                "setToServerValue": "REQUEST_TIME"
+              },
+              {
+                "fieldPath": "c.d",
+                "setToServerValue": "REQUEST_TIME"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/set-st-multi.json
+++ b/firestore/v1/testcase/set-st-multi.json
@@ -1,38 +1,42 @@
 {
-  "description": "set: multiple ServerTimestamp fields",
-  "comment": "A document can have more than one ServerTimestamp field.\nSince all the ServerTimestamp fields are removed, the only field in the update is \"a\".",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\", \"c\": {\"d\": \"ServerTimestamp\"}}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
+  "tests": [
+    {
+      "description": "set: multiple ServerTimestamp fields",
+      "comment": "A document can have more than one ServerTimestamp field.\nSince all the ServerTimestamp fields are removed, the only field in the update is \"a\".",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\", \"c\": {\"d\": \"ServerTimestamp\"}}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b",
+                    "setToServerValue": "REQUEST_TIME"
+                  },
+                  {
+                    "fieldPath": "c.d",
+                    "setToServerValue": "REQUEST_TIME"
+                  }
+                ]
               }
             }
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b",
-                "setToServerValue": "REQUEST_TIME"
-              },
-              {
-                "fieldPath": "c.d",
-                "setToServerValue": "REQUEST_TIME"
-              }
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/set-st-nested.json
+++ b/firestore/v1/testcase/set-st-nested.json
@@ -1,0 +1,34 @@
+{
+  "description": "set: nested ServerTimestamp field",
+  "comment": "A ServerTimestamp value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b\": {\"c\": \"ServerTimestamp\"}}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b.c",
+                "setToServerValue": "REQUEST_TIME"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/set-st-nested.json
+++ b/firestore/v1/testcase/set-st-nested.json
@@ -1,34 +1,38 @@
 {
-  "description": "set: nested ServerTimestamp field",
-  "comment": "A ServerTimestamp value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b\": {\"c\": \"ServerTimestamp\"}}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
+  "tests": [
+    {
+      "description": "set: nested ServerTimestamp field",
+      "comment": "A ServerTimestamp value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b\": {\"c\": \"ServerTimestamp\"}}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b.c",
+                    "setToServerValue": "REQUEST_TIME"
+                  }
+                ]
               }
             }
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b.c",
-                "setToServerValue": "REQUEST_TIME"
-              }
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/set-st-noarray-nested.json
+++ b/firestore/v1/testcase/set-st-noarray-nested.json
@@ -1,0 +1,9 @@
+{
+  "description": "set: ServerTimestamp cannot be anywhere inside an array value",
+  "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ServerTimestamp sentinel. Firestore transforms don't support array indexing.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [1, {\"b\": \"ServerTimestamp\"}]}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/set-st-noarray-nested.json
+++ b/firestore/v1/testcase/set-st-noarray-nested.json
@@ -1,9 +1,13 @@
 {
-  "description": "set: ServerTimestamp cannot be anywhere inside an array value",
-  "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ServerTimestamp sentinel. Firestore transforms don't support array indexing.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [1, {\"b\": \"ServerTimestamp\"}]}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "set: ServerTimestamp cannot be anywhere inside an array value",
+      "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ServerTimestamp sentinel. Firestore transforms don't support array indexing.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [1, {\"b\": \"ServerTimestamp\"}]}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/set-st-noarray.json
+++ b/firestore/v1/testcase/set-st-noarray.json
@@ -1,0 +1,9 @@
+{
+  "description": "set: ServerTimestamp cannot be in an array value",
+  "comment": "The ServerTimestamp sentinel must be the value of a field. Firestore\ntransforms don't support array indexing.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [1, 2, \"ServerTimestamp\"]}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/set-st-noarray.json
+++ b/firestore/v1/testcase/set-st-noarray.json
@@ -1,9 +1,13 @@
 {
-  "description": "set: ServerTimestamp cannot be in an array value",
-  "comment": "The ServerTimestamp sentinel must be the value of a field. Firestore\ntransforms don't support array indexing.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [1, 2, \"ServerTimestamp\"]}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "set: ServerTimestamp cannot be in an array value",
+      "comment": "The ServerTimestamp sentinel must be the value of a field. Firestore\ntransforms don't support array indexing.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [1, 2, \"ServerTimestamp\"]}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/set-st-nomerge.json
+++ b/firestore/v1/testcase/set-st-nomerge.json
@@ -1,0 +1,37 @@
+{
+  "description": "set-merge: If is ServerTimestamp not in Merge, no transform",
+  "comment": "If the ServerTimestamp value is not mentioned in a merge option,\nthen it is pruned from the data but does not result in a transform.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "option": {
+      "fields": [
+        {
+          "field": [
+            "a"
+          ]
+        }
+      ]
+    },
+    "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\"}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a"
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/set-st-nomerge.json
+++ b/firestore/v1/testcase/set-st-nomerge.json
@@ -1,37 +1,41 @@
 {
-  "description": "set-merge: If is ServerTimestamp not in Merge, no transform",
-  "comment": "If the ServerTimestamp value is not mentioned in a merge option,\nthen it is pruned from the data but does not result in a transform.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "option": {
-      "fields": [
-        {
-          "field": [
-            "a"
+  "tests": [
+    {
+      "description": "set-merge: If is ServerTimestamp not in Merge, no transform",
+      "comment": "If the ServerTimestamp value is not mentioned in a merge option,\nthen it is pruned from the data but does not result in a transform.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "option": {
+          "fields": [
+            {
+              "field": [
+                "a"
+              ]
+            }
           ]
-        }
-      ]
-    },
-    "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\"}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
+        },
+        "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\"}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a"
+                ]
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "a"
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/set-st-with-empty-map.json
+++ b/firestore/v1/testcase/set-st-with-empty-map.json
@@ -1,0 +1,42 @@
+{
+  "description": "set: ServerTimestamp beside an empty map",
+  "comment": "When a ServerTimestamp and a map both reside inside a map, the\nServerTimestamp should be stripped out but the empty map should remain.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": {\"b\": {}, \"c\": \"ServerTimestamp\"}}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "mapValue": {
+                  "fields": {
+                    "b": {
+                      "mapValue": {
+                        "fields": {}
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "a.c",
+                "setToServerValue": "REQUEST_TIME"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/set-st-with-empty-map.json
+++ b/firestore/v1/testcase/set-st-with-empty-map.json
@@ -1,42 +1,46 @@
 {
-  "description": "set: ServerTimestamp beside an empty map",
-  "comment": "When a ServerTimestamp and a map both reside inside a map, the\nServerTimestamp should be stripped out but the empty map should remain.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": {\"b\": {}, \"c\": \"ServerTimestamp\"}}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "mapValue": {
-                  "fields": {
-                    "b": {
-                      "mapValue": {
-                        "fields": {}
+  "tests": [
+    {
+      "description": "set: ServerTimestamp beside an empty map",
+      "comment": "When a ServerTimestamp and a map both reside inside a map, the\nServerTimestamp should be stripped out but the empty map should remain.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": {\"b\": {}, \"c\": \"ServerTimestamp\"}}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "mapValue": {
+                      "fields": {
+                        "b": {
+                          "mapValue": {
+                            "fields": {}
+                          }
+                        }
                       }
                     }
                   }
                 }
               }
-            }
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "a.c",
-                "setToServerValue": "REQUEST_TIME"
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "a.c",
+                    "setToServerValue": "REQUEST_TIME"
+                  }
+                ]
               }
-            ]
-          }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/set-st.json
+++ b/firestore/v1/testcase/set-st.json
@@ -1,0 +1,34 @@
+{
+  "description": "set: ServerTimestamp with data",
+  "comment": "A key with the special ServerTimestamp sentinel is removed from\nthe data in the update operation. Instead it appears in a separate Transform operation.\nNote that in these tests, the string \"ServerTimestamp\" should be replaced with the\nspecial ServerTimestamp value.",
+  "set": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\"}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b",
+                "setToServerValue": "REQUEST_TIME"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/set-st.json
+++ b/firestore/v1/testcase/set-st.json
@@ -1,34 +1,38 @@
 {
-  "description": "set: ServerTimestamp with data",
-  "comment": "A key with the special ServerTimestamp sentinel is removed from\nthe data in the update operation. Instead it appears in a separate Transform operation.\nNote that in these tests, the string \"ServerTimestamp\" should be replaced with the\nspecial ServerTimestamp value.",
-  "set": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\"}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
+  "tests": [
+    {
+      "description": "set: ServerTimestamp with data",
+      "comment": "A key with the special ServerTimestamp sentinel is removed from\nthe data in the update operation. Instead it appears in a separate Transform operation.\nNote that in these tests, the string \"ServerTimestamp\" should be replaced with the\nspecial ServerTimestamp value.",
+      "set": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\"}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b",
+                    "setToServerValue": "REQUEST_TIME"
+                  }
+                ]
               }
             }
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b",
-                "setToServerValue": "REQUEST_TIME"
-              }
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-all-transforms.json
+++ b/firestore/v1/testcase/update-all-transforms.json
@@ -1,0 +1,74 @@
+{
+  "description": "update: all transforms in a single call",
+  "comment": "A document can be created with any amount of transforms.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\", \"c\": [\"ArrayUnion\", 1, 2, 3], \"d\": [\"ArrayRemove\", 4, 5, 6]}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b",
+                "setToServerValue": "REQUEST_TIME"
+              },
+              {
+                "fieldPath": "c",
+                "appendMissingElements": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "integerValue": "2"
+                    },
+                    {
+                      "integerValue": "3"
+                    }
+                  ]
+                }
+              },
+              {
+                "fieldPath": "d",
+                "removeAllFromArray": {
+                  "values": [
+                    {
+                      "integerValue": "4"
+                    },
+                    {
+                      "integerValue": "5"
+                    },
+                    {
+                      "integerValue": "6"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-all-transforms.json
+++ b/firestore/v1/testcase/update-all-transforms.json
@@ -1,74 +1,78 @@
 {
-  "description": "update: all transforms in a single call",
-  "comment": "A document can be created with any amount of transforms.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\", \"c\": [\"ArrayUnion\", 1, 2, 3], \"d\": [\"ArrayRemove\", 4, 5, 6]}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
+  "tests": [
+    {
+      "description": "update: all transforms in a single call",
+      "comment": "A document can be created with any amount of transforms.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\", \"c\": [\"ArrayUnion\", 1, 2, 3], \"d\": [\"ArrayRemove\", 4, 5, 6]}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b",
+                    "setToServerValue": "REQUEST_TIME"
+                  },
+                  {
+                    "fieldPath": "c",
+                    "appendMissingElements": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "integerValue": "2"
+                        },
+                        {
+                          "integerValue": "3"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "fieldPath": "d",
+                    "removeAllFromArray": {
+                      "values": [
+                        {
+                          "integerValue": "4"
+                        },
+                        {
+                          "integerValue": "5"
+                        },
+                        {
+                          "integerValue": "6"
+                        }
+                      ]
+                    }
+                  }
+                ]
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "a"
-            ]
-          },
-          "currentDocument": {
-            "exists": true
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b",
-                "setToServerValue": "REQUEST_TIME"
-              },
-              {
-                "fieldPath": "c",
-                "appendMissingElements": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "integerValue": "2"
-                    },
-                    {
-                      "integerValue": "3"
-                    }
-                  ]
-                }
-              },
-              {
-                "fieldPath": "d",
-                "removeAllFromArray": {
-                  "values": [
-                    {
-                      "integerValue": "4"
-                    },
-                    {
-                      "integerValue": "5"
-                    },
-                    {
-                      "integerValue": "6"
-                    }
-                  ]
-                }
-              }
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-arrayremove-alone.json
+++ b/firestore/v1/testcase/update-arrayremove-alone.json
@@ -1,0 +1,39 @@
+{
+  "description": "update: ArrayRemove alone",
+  "comment": "If the only values in the input are ArrayRemove, then no\nupdate operation should be produced.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [\"ArrayRemove\", 1, 2, 3]}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "a",
+                "removeAllFromArray": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "integerValue": "2"
+                    },
+                    {
+                      "integerValue": "3"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-arrayremove-alone.json
+++ b/firestore/v1/testcase/update-arrayremove-alone.json
@@ -1,39 +1,43 @@
 {
-  "description": "update: ArrayRemove alone",
-  "comment": "If the only values in the input are ArrayRemove, then no\nupdate operation should be produced.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [\"ArrayRemove\", 1, 2, 3]}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "a",
-                "removeAllFromArray": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "integerValue": "2"
-                    },
-                    {
-                      "integerValue": "3"
+  "tests": [
+    {
+      "description": "update: ArrayRemove alone",
+      "comment": "If the only values in the input are ArrayRemove, then no\nupdate operation should be produced.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [\"ArrayRemove\", 1, 2, 3]}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "a",
+                    "removeAllFromArray": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "integerValue": "2"
+                        },
+                        {
+                          "integerValue": "3"
+                        }
+                      ]
                     }
-                  ]
-                }
+                  }
+                ]
+              },
+              "currentDocument": {
+                "exists": true
               }
-            ]
-          },
-          "currentDocument": {
-            "exists": true
-          }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-arrayremove-multi.json
+++ b/firestore/v1/testcase/update-arrayremove-multi.json
@@ -1,0 +1,71 @@
+{
+  "description": "update: multiple ArrayRemove fields",
+  "comment": "A document can have more than one ArrayRemove field.\nSince all the ArrayRemove fields are removed, the only field in the update is \"a\".",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b\": [\"ArrayRemove\", 1, 2, 3], \"c\": {\"d\": [\"ArrayRemove\", 4, 5, 6]}}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a",
+              "c"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b",
+                "removeAllFromArray": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "integerValue": "2"
+                    },
+                    {
+                      "integerValue": "3"
+                    }
+                  ]
+                }
+              },
+              {
+                "fieldPath": "c.d",
+                "removeAllFromArray": {
+                  "values": [
+                    {
+                      "integerValue": "4"
+                    },
+                    {
+                      "integerValue": "5"
+                    },
+                    {
+                      "integerValue": "6"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-arrayremove-multi.json
+++ b/firestore/v1/testcase/update-arrayremove-multi.json
@@ -1,71 +1,75 @@
 {
-  "description": "update: multiple ArrayRemove fields",
-  "comment": "A document can have more than one ArrayRemove field.\nSince all the ArrayRemove fields are removed, the only field in the update is \"a\".",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b\": [\"ArrayRemove\", 1, 2, 3], \"c\": {\"d\": [\"ArrayRemove\", 4, 5, 6]}}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "a",
-              "c"
-            ]
-          },
-          "currentDocument": {
-            "exists": true
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b",
-                "removeAllFromArray": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "integerValue": "2"
-                    },
-                    {
-                      "integerValue": "3"
-                    }
-                  ]
+  "tests": [
+    {
+      "description": "update: multiple ArrayRemove fields",
+      "comment": "A document can have more than one ArrayRemove field.\nSince all the ArrayRemove fields are removed, the only field in the update is \"a\".",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b\": [\"ArrayRemove\", 1, 2, 3], \"c\": {\"d\": [\"ArrayRemove\", 4, 5, 6]}}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
                 }
               },
-              {
-                "fieldPath": "c.d",
-                "removeAllFromArray": {
-                  "values": [
-                    {
-                      "integerValue": "4"
-                    },
-                    {
-                      "integerValue": "5"
-                    },
-                    {
-                      "integerValue": "6"
-                    }
-                  ]
-                }
+              "updateMask": {
+                "fieldPaths": [
+                  "a",
+                  "c"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
               }
-            ]
-          }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b",
+                    "removeAllFromArray": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "integerValue": "2"
+                        },
+                        {
+                          "integerValue": "3"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "fieldPath": "c.d",
+                    "removeAllFromArray": {
+                      "values": [
+                        {
+                          "integerValue": "4"
+                        },
+                        {
+                          "integerValue": "5"
+                        },
+                        {
+                          "integerValue": "6"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-arrayremove-nested.json
+++ b/firestore/v1/testcase/update-arrayremove-nested.json
@@ -1,0 +1,55 @@
+{
+  "description": "update: nested ArrayRemove field",
+  "comment": "An ArrayRemove value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b\": {\"c\": [\"ArrayRemove\", 1, 2, 3]}}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a",
+              "b"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b.c",
+                "removeAllFromArray": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "integerValue": "2"
+                    },
+                    {
+                      "integerValue": "3"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-arrayremove-nested.json
+++ b/firestore/v1/testcase/update-arrayremove-nested.json
@@ -1,55 +1,59 @@
 {
-  "description": "update: nested ArrayRemove field",
-  "comment": "An ArrayRemove value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b\": {\"c\": [\"ArrayRemove\", 1, 2, 3]}}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
+  "tests": [
+    {
+      "description": "update: nested ArrayRemove field",
+      "comment": "An ArrayRemove value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b\": {\"c\": [\"ArrayRemove\", 1, 2, 3]}}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a",
+                  "b"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b.c",
+                    "removeAllFromArray": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "integerValue": "2"
+                        },
+                        {
+                          "integerValue": "3"
+                        }
+                      ]
+                    }
+                  }
+                ]
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "a",
-              "b"
-            ]
-          },
-          "currentDocument": {
-            "exists": true
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b.c",
-                "removeAllFromArray": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "integerValue": "2"
-                    },
-                    {
-                      "integerValue": "3"
-                    }
-                  ]
-                }
-              }
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-arrayremove-noarray-nested.json
+++ b/firestore/v1/testcase/update-arrayremove-noarray-nested.json
@@ -1,0 +1,9 @@
+{
+  "description": "update: ArrayRemove cannot be anywhere inside an array value",
+  "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ArrayRemove. Firestore transforms don't support array indexing.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [1, {\"b\": [\"ArrayRemove\", 1, 2, 3]}]}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-arrayremove-noarray-nested.json
+++ b/firestore/v1/testcase/update-arrayremove-noarray-nested.json
@@ -1,9 +1,13 @@
 {
-  "description": "update: ArrayRemove cannot be anywhere inside an array value",
-  "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ArrayRemove. Firestore transforms don't support array indexing.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [1, {\"b\": [\"ArrayRemove\", 1, 2, 3]}]}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "update: ArrayRemove cannot be anywhere inside an array value",
+      "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ArrayRemove. Firestore transforms don't support array indexing.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [1, {\"b\": [\"ArrayRemove\", 1, 2, 3]}]}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-arrayremove-noarray.json
+++ b/firestore/v1/testcase/update-arrayremove-noarray.json
@@ -1,0 +1,9 @@
+{
+  "description": "update: ArrayRemove cannot be in an array value",
+  "comment": "ArrayRemove must be the value of a field. Firestore\ntransforms don't support array indexing.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [1, 2, [\"ArrayRemove\", 1, 2, 3]]}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-arrayremove-noarray.json
+++ b/firestore/v1/testcase/update-arrayremove-noarray.json
@@ -1,9 +1,13 @@
 {
-  "description": "update: ArrayRemove cannot be in an array value",
-  "comment": "ArrayRemove must be the value of a field. Firestore\ntransforms don't support array indexing.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [1, 2, [\"ArrayRemove\", 1, 2, 3]]}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "update: ArrayRemove cannot be in an array value",
+      "comment": "ArrayRemove must be the value of a field. Firestore\ntransforms don't support array indexing.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [1, 2, [\"ArrayRemove\", 1, 2, 3]]}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-arrayremove-with-st.json
+++ b/firestore/v1/testcase/update-arrayremove-with-st.json
@@ -1,0 +1,9 @@
+{
+  "description": "update: The ServerTimestamp sentinel cannot be in an ArrayUnion",
+  "comment": "The ServerTimestamp sentinel must be the value of a field. It may\nnot appear in an ArrayUnion.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [\"ArrayRemove\", 1, \"ServerTimestamp\", 3]}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-arrayremove-with-st.json
+++ b/firestore/v1/testcase/update-arrayremove-with-st.json
@@ -1,9 +1,13 @@
 {
-  "description": "update: The ServerTimestamp sentinel cannot be in an ArrayUnion",
-  "comment": "The ServerTimestamp sentinel must be the value of a field. It may\nnot appear in an ArrayUnion.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [\"ArrayRemove\", 1, \"ServerTimestamp\", 3]}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "update: The ServerTimestamp sentinel cannot be in an ArrayUnion",
+      "comment": "The ServerTimestamp sentinel must be the value of a field. It may\nnot appear in an ArrayUnion.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [\"ArrayRemove\", 1, \"ServerTimestamp\", 3]}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-arrayremove.json
+++ b/firestore/v1/testcase/update-arrayremove.json
@@ -1,0 +1,54 @@
+{
+  "description": "update: ArrayRemove with data",
+  "comment": "A key with ArrayRemove is removed from the data in the update \noperation. Instead it appears in a separate Transform operation.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b\": [\"ArrayRemove\", 1, 2, 3]}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b",
+                "removeAllFromArray": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "integerValue": "2"
+                    },
+                    {
+                      "integerValue": "3"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-arrayremove.json
+++ b/firestore/v1/testcase/update-arrayremove.json
@@ -1,54 +1,58 @@
 {
-  "description": "update: ArrayRemove with data",
-  "comment": "A key with ArrayRemove is removed from the data in the update \noperation. Instead it appears in a separate Transform operation.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b\": [\"ArrayRemove\", 1, 2, 3]}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
+  "tests": [
+    {
+      "description": "update: ArrayRemove with data",
+      "comment": "A key with ArrayRemove is removed from the data in the update \noperation. Instead it appears in a separate Transform operation.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b\": [\"ArrayRemove\", 1, 2, 3]}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b",
+                    "removeAllFromArray": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "integerValue": "2"
+                        },
+                        {
+                          "integerValue": "3"
+                        }
+                      ]
+                    }
+                  }
+                ]
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "a"
-            ]
-          },
-          "currentDocument": {
-            "exists": true
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b",
-                "removeAllFromArray": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "integerValue": "2"
-                    },
-                    {
-                      "integerValue": "3"
-                    }
-                  ]
-                }
-              }
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-arrayunion-alone.json
+++ b/firestore/v1/testcase/update-arrayunion-alone.json
@@ -1,0 +1,39 @@
+{
+  "description": "update: ArrayUnion alone",
+  "comment": "If the only values in the input are ArrayUnion, then no\nupdate operation should be produced.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [\"ArrayUnion\", 1, 2, 3]}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "a",
+                "appendMissingElements": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "integerValue": "2"
+                    },
+                    {
+                      "integerValue": "3"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-arrayunion-alone.json
+++ b/firestore/v1/testcase/update-arrayunion-alone.json
@@ -1,39 +1,43 @@
 {
-  "description": "update: ArrayUnion alone",
-  "comment": "If the only values in the input are ArrayUnion, then no\nupdate operation should be produced.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [\"ArrayUnion\", 1, 2, 3]}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "a",
-                "appendMissingElements": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "integerValue": "2"
-                    },
-                    {
-                      "integerValue": "3"
+  "tests": [
+    {
+      "description": "update: ArrayUnion alone",
+      "comment": "If the only values in the input are ArrayUnion, then no\nupdate operation should be produced.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [\"ArrayUnion\", 1, 2, 3]}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "a",
+                    "appendMissingElements": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "integerValue": "2"
+                        },
+                        {
+                          "integerValue": "3"
+                        }
+                      ]
                     }
-                  ]
-                }
+                  }
+                ]
+              },
+              "currentDocument": {
+                "exists": true
               }
-            ]
-          },
-          "currentDocument": {
-            "exists": true
-          }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-arrayunion-multi.json
+++ b/firestore/v1/testcase/update-arrayunion-multi.json
@@ -1,0 +1,71 @@
+{
+  "description": "update: multiple ArrayUnion fields",
+  "comment": "A document can have more than one ArrayUnion field.\nSince all the ArrayUnion fields are removed, the only field in the update is \"a\".",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b\": [\"ArrayUnion\", 1, 2, 3], \"c\": {\"d\": [\"ArrayUnion\", 4, 5, 6]}}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a",
+              "c"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b",
+                "appendMissingElements": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "integerValue": "2"
+                    },
+                    {
+                      "integerValue": "3"
+                    }
+                  ]
+                }
+              },
+              {
+                "fieldPath": "c.d",
+                "appendMissingElements": {
+                  "values": [
+                    {
+                      "integerValue": "4"
+                    },
+                    {
+                      "integerValue": "5"
+                    },
+                    {
+                      "integerValue": "6"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-arrayunion-multi.json
+++ b/firestore/v1/testcase/update-arrayunion-multi.json
@@ -1,71 +1,75 @@
 {
-  "description": "update: multiple ArrayUnion fields",
-  "comment": "A document can have more than one ArrayUnion field.\nSince all the ArrayUnion fields are removed, the only field in the update is \"a\".",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b\": [\"ArrayUnion\", 1, 2, 3], \"c\": {\"d\": [\"ArrayUnion\", 4, 5, 6]}}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "a",
-              "c"
-            ]
-          },
-          "currentDocument": {
-            "exists": true
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b",
-                "appendMissingElements": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "integerValue": "2"
-                    },
-                    {
-                      "integerValue": "3"
-                    }
-                  ]
+  "tests": [
+    {
+      "description": "update: multiple ArrayUnion fields",
+      "comment": "A document can have more than one ArrayUnion field.\nSince all the ArrayUnion fields are removed, the only field in the update is \"a\".",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b\": [\"ArrayUnion\", 1, 2, 3], \"c\": {\"d\": [\"ArrayUnion\", 4, 5, 6]}}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
                 }
               },
-              {
-                "fieldPath": "c.d",
-                "appendMissingElements": {
-                  "values": [
-                    {
-                      "integerValue": "4"
-                    },
-                    {
-                      "integerValue": "5"
-                    },
-                    {
-                      "integerValue": "6"
-                    }
-                  ]
-                }
+              "updateMask": {
+                "fieldPaths": [
+                  "a",
+                  "c"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
               }
-            ]
-          }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b",
+                    "appendMissingElements": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "integerValue": "2"
+                        },
+                        {
+                          "integerValue": "3"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "fieldPath": "c.d",
+                    "appendMissingElements": {
+                      "values": [
+                        {
+                          "integerValue": "4"
+                        },
+                        {
+                          "integerValue": "5"
+                        },
+                        {
+                          "integerValue": "6"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-arrayunion-nested.json
+++ b/firestore/v1/testcase/update-arrayunion-nested.json
@@ -1,0 +1,55 @@
+{
+  "description": "update: nested ArrayUnion field",
+  "comment": "An ArrayUnion value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b\": {\"c\": [\"ArrayUnion\", 1, 2, 3]}}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a",
+              "b"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b.c",
+                "appendMissingElements": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "integerValue": "2"
+                    },
+                    {
+                      "integerValue": "3"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-arrayunion-nested.json
+++ b/firestore/v1/testcase/update-arrayunion-nested.json
@@ -1,55 +1,59 @@
 {
-  "description": "update: nested ArrayUnion field",
-  "comment": "An ArrayUnion value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b\": {\"c\": [\"ArrayUnion\", 1, 2, 3]}}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
+  "tests": [
+    {
+      "description": "update: nested ArrayUnion field",
+      "comment": "An ArrayUnion value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b\": {\"c\": [\"ArrayUnion\", 1, 2, 3]}}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a",
+                  "b"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b.c",
+                    "appendMissingElements": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "integerValue": "2"
+                        },
+                        {
+                          "integerValue": "3"
+                        }
+                      ]
+                    }
+                  }
+                ]
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "a",
-              "b"
-            ]
-          },
-          "currentDocument": {
-            "exists": true
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b.c",
-                "appendMissingElements": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "integerValue": "2"
-                    },
-                    {
-                      "integerValue": "3"
-                    }
-                  ]
-                }
-              }
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-arrayunion-noarray-nested.json
+++ b/firestore/v1/testcase/update-arrayunion-noarray-nested.json
@@ -1,0 +1,9 @@
+{
+  "description": "update: ArrayUnion cannot be anywhere inside an array value",
+  "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ArrayUnion. Firestore transforms don't support array indexing.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [1, {\"b\": [\"ArrayUnion\", 1, 2, 3]}]}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-arrayunion-noarray-nested.json
+++ b/firestore/v1/testcase/update-arrayunion-noarray-nested.json
@@ -1,9 +1,13 @@
 {
-  "description": "update: ArrayUnion cannot be anywhere inside an array value",
-  "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ArrayUnion. Firestore transforms don't support array indexing.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [1, {\"b\": [\"ArrayUnion\", 1, 2, 3]}]}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "update: ArrayUnion cannot be anywhere inside an array value",
+      "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ArrayUnion. Firestore transforms don't support array indexing.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [1, {\"b\": [\"ArrayUnion\", 1, 2, 3]}]}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-arrayunion-noarray.json
+++ b/firestore/v1/testcase/update-arrayunion-noarray.json
@@ -1,0 +1,9 @@
+{
+  "description": "update: ArrayUnion cannot be in an array value",
+  "comment": "ArrayUnion must be the value of a field. Firestore\ntransforms don't support array indexing.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [1, 2, [\"ArrayRemove\", 1, 2, 3]]}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-arrayunion-noarray.json
+++ b/firestore/v1/testcase/update-arrayunion-noarray.json
@@ -1,9 +1,13 @@
 {
-  "description": "update: ArrayUnion cannot be in an array value",
-  "comment": "ArrayUnion must be the value of a field. Firestore\ntransforms don't support array indexing.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [1, 2, [\"ArrayRemove\", 1, 2, 3]]}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "update: ArrayUnion cannot be in an array value",
+      "comment": "ArrayUnion must be the value of a field. Firestore\ntransforms don't support array indexing.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [1, 2, [\"ArrayRemove\", 1, 2, 3]]}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-arrayunion-with-st.json
+++ b/firestore/v1/testcase/update-arrayunion-with-st.json
@@ -1,0 +1,9 @@
+{
+  "description": "update: The ServerTimestamp sentinel cannot be in an ArrayUnion",
+  "comment": "The ServerTimestamp sentinel must be the value of a field. It may\nnot appear in an ArrayUnion.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [\"ArrayUnion\", 1, \"ServerTimestamp\", 3]}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-arrayunion-with-st.json
+++ b/firestore/v1/testcase/update-arrayunion-with-st.json
@@ -1,9 +1,13 @@
 {
-  "description": "update: The ServerTimestamp sentinel cannot be in an ArrayUnion",
-  "comment": "The ServerTimestamp sentinel must be the value of a field. It may\nnot appear in an ArrayUnion.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [\"ArrayUnion\", 1, \"ServerTimestamp\", 3]}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "update: The ServerTimestamp sentinel cannot be in an ArrayUnion",
+      "comment": "The ServerTimestamp sentinel must be the value of a field. It may\nnot appear in an ArrayUnion.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [\"ArrayUnion\", 1, \"ServerTimestamp\", 3]}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-arrayunion.json
+++ b/firestore/v1/testcase/update-arrayunion.json
@@ -1,0 +1,54 @@
+{
+  "description": "update: ArrayUnion with data",
+  "comment": "A key with ArrayUnion is removed from the data in the update \noperation. Instead it appears in a separate Transform operation.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b\": [\"ArrayUnion\", 1, 2, 3]}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b",
+                "appendMissingElements": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "integerValue": "2"
+                    },
+                    {
+                      "integerValue": "3"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-arrayunion.json
+++ b/firestore/v1/testcase/update-arrayunion.json
@@ -1,54 +1,58 @@
 {
-  "description": "update: ArrayUnion with data",
-  "comment": "A key with ArrayUnion is removed from the data in the update \noperation. Instead it appears in a separate Transform operation.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b\": [\"ArrayUnion\", 1, 2, 3]}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
+  "tests": [
+    {
+      "description": "update: ArrayUnion with data",
+      "comment": "A key with ArrayUnion is removed from the data in the update \noperation. Instead it appears in a separate Transform operation.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b\": [\"ArrayUnion\", 1, 2, 3]}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b",
+                    "appendMissingElements": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "integerValue": "2"
+                        },
+                        {
+                          "integerValue": "3"
+                        }
+                      ]
+                    }
+                  }
+                ]
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "a"
-            ]
-          },
-          "currentDocument": {
-            "exists": true
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b",
-                "appendMissingElements": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "integerValue": "2"
-                    },
-                    {
-                      "integerValue": "3"
-                    }
-                  ]
-                }
-              }
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-badchar.json
+++ b/firestore/v1/testcase/update-badchar.json
@@ -1,0 +1,9 @@
+{
+  "description": "update: invalid character",
+  "comment": "The keys of the data given to Update are interpreted, unlike those of Create and Set. They cannot contain special characters.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a~b\": 1}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-badchar.json
+++ b/firestore/v1/testcase/update-badchar.json
@@ -1,9 +1,13 @@
 {
-  "description": "update: invalid character",
-  "comment": "The keys of the data given to Update are interpreted, unlike those of Create and Set. They cannot contain special characters.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a~b\": 1}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "update: invalid character",
+      "comment": "The keys of the data given to Update are interpreted, unlike those of Create and Set. They cannot contain special characters.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a~b\": 1}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-basic.json
+++ b/firestore/v1/testcase/update-basic.json
@@ -1,0 +1,31 @@
+{
+  "description": "update: basic",
+  "comment": "A simple call, resulting in a single update operation.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-basic.json
+++ b/firestore/v1/testcase/update-basic.json
@@ -1,31 +1,35 @@
 {
-  "description": "update: basic",
-  "comment": "A simple call, resulting in a single update operation.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
+  "tests": [
+    {
+      "description": "update: basic",
+      "comment": "A simple call, resulting in a single update operation.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "a"
-            ]
-          },
-          "currentDocument": {
-            "exists": true
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-complex.json
+++ b/firestore/v1/testcase/update-complex.json
@@ -1,0 +1,65 @@
+{
+  "description": "update: complex",
+  "comment": "A call to a write method with complicated input data.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [1, 2.5], \"b\": {\"c\": [\"three\", {\"d\": true}]}}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "arrayValue": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "doubleValue": 2.5
+                    }
+                  ]
+                }
+              },
+              "b": {
+                "mapValue": {
+                  "fields": {
+                    "c": {
+                      "arrayValue": {
+                        "values": [
+                          {
+                            "stringValue": "three"
+                          },
+                          {
+                            "mapValue": {
+                              "fields": {
+                                "d": {
+                                  "booleanValue": true
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a",
+              "b"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-complex.json
+++ b/firestore/v1/testcase/update-complex.json
@@ -1,65 +1,69 @@
 {
-  "description": "update: complex",
-  "comment": "A call to a write method with complicated input data.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [1, 2.5], \"b\": {\"c\": [\"three\", {\"d\": true}]}}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "arrayValue": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "doubleValue": 2.5
+  "tests": [
+    {
+      "description": "update: complex",
+      "comment": "A call to a write method with complicated input data.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [1, 2.5], \"b\": {\"c\": [\"three\", {\"d\": true}]}}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "arrayValue": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "doubleValue": 2.5
+                        }
+                      ]
                     }
-                  ]
-                }
-              },
-              "b": {
-                "mapValue": {
-                  "fields": {
-                    "c": {
-                      "arrayValue": {
-                        "values": [
-                          {
-                            "stringValue": "three"
-                          },
-                          {
-                            "mapValue": {
-                              "fields": {
-                                "d": {
-                                  "booleanValue": true
+                  },
+                  "b": {
+                    "mapValue": {
+                      "fields": {
+                        "c": {
+                          "arrayValue": {
+                            "values": [
+                              {
+                                "stringValue": "three"
+                              },
+                              {
+                                "mapValue": {
+                                  "fields": {
+                                    "d": {
+                                      "booleanValue": true
+                                    }
+                                  }
                                 }
                               }
-                            }
+                            ]
                           }
-                        ]
+                        }
                       }
                     }
                   }
                 }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a",
+                  "b"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "a",
-              "b"
-            ]
-          },
-          "currentDocument": {
-            "exists": true
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-del-alone.json
+++ b/firestore/v1/testcase/update-del-alone.json
@@ -1,0 +1,26 @@
+{
+  "description": "update: Delete alone",
+  "comment": "If the input data consists solely of Deletes, then the update\noperation has no map, just an update mask.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": \"Delete\"}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d"
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-del-alone.json
+++ b/firestore/v1/testcase/update-del-alone.json
@@ -1,26 +1,30 @@
 {
-  "description": "update: Delete alone",
-  "comment": "If the input data consists solely of Deletes, then the update\noperation has no map, just an update mask.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": \"Delete\"}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d"
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "a"
-            ]
-          },
-          "currentDocument": {
-            "exists": true
-          }
+  "tests": [
+    {
+      "description": "update: Delete alone",
+      "comment": "If the input data consists solely of Deletes, then the update\noperation has no map, just an update mask.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": \"Delete\"}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d"
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
+              }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-del-dot.json
+++ b/firestore/v1/testcase/update-del-dot.json
@@ -1,0 +1,42 @@
+{
+  "description": "update: Delete with a dotted field",
+  "comment": "After expanding top-level dotted fields, fields with Delete\nvalues are pruned from the output data, but appear in the update mask.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b.c\": \"Delete\", \"b.d\": 2}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              },
+              "b": {
+                "mapValue": {
+                  "fields": {
+                    "d": {
+                      "integerValue": "2"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a",
+              "b.c",
+              "b.d"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-del-dot.json
+++ b/firestore/v1/testcase/update-del-dot.json
@@ -1,42 +1,46 @@
 {
-  "description": "update: Delete with a dotted field",
-  "comment": "After expanding top-level dotted fields, fields with Delete\nvalues are pruned from the output data, but appear in the update mask.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b.c\": \"Delete\", \"b.d\": 2}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              },
-              "b": {
-                "mapValue": {
-                  "fields": {
-                    "d": {
-                      "integerValue": "2"
+  "tests": [
+    {
+      "description": "update: Delete with a dotted field",
+      "comment": "After expanding top-level dotted fields, fields with Delete\nvalues are pruned from the output data, but appear in the update mask.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b.c\": \"Delete\", \"b.d\": 2}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  },
+                  "b": {
+                    "mapValue": {
+                      "fields": {
+                        "d": {
+                          "integerValue": "2"
+                        }
+                      }
                     }
                   }
                 }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a",
+                  "b.c",
+                  "b.d"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "a",
-              "b.c",
-              "b.d"
-            ]
-          },
-          "currentDocument": {
-            "exists": true
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-del-nested.json
+++ b/firestore/v1/testcase/update-del-nested.json
@@ -1,0 +1,9 @@
+{
+  "description": "update: Delete cannot be nested",
+  "comment": "The Delete sentinel must be the value of a top-level key.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": {\"b\": \"Delete\"}}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-del-nested.json
+++ b/firestore/v1/testcase/update-del-nested.json
@@ -1,9 +1,13 @@
 {
-  "description": "update: Delete cannot be nested",
-  "comment": "The Delete sentinel must be the value of a top-level key.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": {\"b\": \"Delete\"}}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "update: Delete cannot be nested",
+      "comment": "The Delete sentinel must be the value of a top-level key.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": {\"b\": \"Delete\"}}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-del-noarray-nested.json
+++ b/firestore/v1/testcase/update-del-noarray-nested.json
@@ -1,0 +1,9 @@
+{
+  "description": "update: Delete cannot be anywhere inside an array value",
+  "comment": "The Delete sentinel must be the value of a field. Deletes are implemented\nby turning the path to the Delete sentinel into a FieldPath, and FieldPaths do not support\narray indexing.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [1, {\"b\": \"Delete\"}]}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-del-noarray-nested.json
+++ b/firestore/v1/testcase/update-del-noarray-nested.json
@@ -1,9 +1,13 @@
 {
-  "description": "update: Delete cannot be anywhere inside an array value",
-  "comment": "The Delete sentinel must be the value of a field. Deletes are implemented\nby turning the path to the Delete sentinel into a FieldPath, and FieldPaths do not support\narray indexing.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [1, {\"b\": \"Delete\"}]}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "update: Delete cannot be anywhere inside an array value",
+      "comment": "The Delete sentinel must be the value of a field. Deletes are implemented\nby turning the path to the Delete sentinel into a FieldPath, and FieldPaths do not support\narray indexing.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [1, {\"b\": \"Delete\"}]}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-del-noarray.json
+++ b/firestore/v1/testcase/update-del-noarray.json
@@ -1,0 +1,9 @@
+{
+  "description": "update: Delete cannot be in an array value",
+  "comment": "The Delete sentinel must be the value of a field. Deletes are\nimplemented by turning the path to the Delete sentinel into a FieldPath, and FieldPaths\ndo not support array indexing.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [1, 2, \"Delete\"]}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-del-noarray.json
+++ b/firestore/v1/testcase/update-del-noarray.json
@@ -1,9 +1,13 @@
 {
-  "description": "update: Delete cannot be in an array value",
-  "comment": "The Delete sentinel must be the value of a field. Deletes are\nimplemented by turning the path to the Delete sentinel into a FieldPath, and FieldPaths\ndo not support array indexing.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [1, 2, \"Delete\"]}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "update: Delete cannot be in an array value",
+      "comment": "The Delete sentinel must be the value of a field. Deletes are\nimplemented by turning the path to the Delete sentinel into a FieldPath, and FieldPaths\ndo not support array indexing.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [1, 2, \"Delete\"]}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-del.json
+++ b/firestore/v1/testcase/update-del.json
@@ -1,0 +1,32 @@
+{
+  "description": "update: Delete",
+  "comment": "If a field's value is the Delete sentinel, then it doesn't appear\nin the update data, but does in the mask.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b\": \"Delete\"}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a",
+              "b"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-del.json
+++ b/firestore/v1/testcase/update-del.json
@@ -1,32 +1,36 @@
 {
-  "description": "update: Delete",
-  "comment": "If a field's value is the Delete sentinel, then it doesn't appear\nin the update data, but does in the mask.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b\": \"Delete\"}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
+  "tests": [
+    {
+      "description": "update: Delete",
+      "comment": "If a field's value is the Delete sentinel, then it doesn't appear\nin the update data, but does in the mask.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b\": \"Delete\"}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a",
+                  "b"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "a",
-              "b"
-            ]
-          },
-          "currentDocument": {
-            "exists": true
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-exists-precond.json
+++ b/firestore/v1/testcase/update-exists-precond.json
@@ -1,0 +1,12 @@
+{
+  "description": "update: Exists precondition is invalid",
+  "comment": "The Update method does not support an explicit exists precondition.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "precondition": {
+      "exists": true
+    },
+    "jsonData": "{\"a\": 1}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-exists-precond.json
+++ b/firestore/v1/testcase/update-exists-precond.json
@@ -1,12 +1,16 @@
 {
-  "description": "update: Exists precondition is invalid",
-  "comment": "The Update method does not support an explicit exists precondition.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "precondition": {
-      "exists": true
-    },
-    "jsonData": "{\"a\": 1}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "update: Exists precondition is invalid",
+      "comment": "The Update method does not support an explicit exists precondition.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "precondition": {
+          "exists": true
+        },
+        "jsonData": "{\"a\": 1}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-fp-empty-component.json
+++ b/firestore/v1/testcase/update-fp-empty-component.json
@@ -1,0 +1,9 @@
+{
+  "description": "update: empty field path component",
+  "comment": "Empty fields are not allowed.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a..b\": 1}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-fp-empty-component.json
+++ b/firestore/v1/testcase/update-fp-empty-component.json
@@ -1,9 +1,13 @@
 {
-  "description": "update: empty field path component",
-  "comment": "Empty fields are not allowed.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a..b\": 1}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "update: empty field path component",
+      "comment": "Empty fields are not allowed.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a..b\": 1}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-nested-transform-and-nested-value.json
+++ b/firestore/v1/testcase/update-nested-transform-and-nested-value.json
@@ -1,0 +1,48 @@
+{
+  "description": "update: Nested transforms should not affect the field mask, even\nwhen there are other values that do. Transforms should only affect the\nDocumentTransform_FieldTransform list.",
+  "comment": "For updates, top-level paths in json-like map inputs\nare split on the dot. That is, an input {\"a.b.c\": 7} results in an update to\nfield c of object b of object a with value 7. In order to specify this behavior,\nthe update must use a fieldmask \"a.b.c\". However, fieldmasks are only used for\nconcrete values - transforms are separately encoded in a\nDocumentTransform_FieldTransform array.\n\nThis test exercises a bug found in python (https://github.com/googleapis/google-cloud-python/issues/7215)\nin which nested transforms ({\"a.c\": \"ServerTimestamp\"}) next to nested values\n({\"a.b\": 7}) incorrectly caused the fieldmask \"a\" to be set, which has the\neffect of wiping out all data in \"a\" other than what was specified in the\njson-like input.\n\nInstead, as this test specifies, transforms should not affect the fieldmask.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a.b\": 7, \"a.c\": \"ServerTimestamp\"}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "mapValue": {
+                  "fields": {
+                    "b": {
+                      "integerValue": "7"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a.b"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "a.c",
+                "setToServerValue": "REQUEST_TIME"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-nested-transform-and-nested-value.json
+++ b/firestore/v1/testcase/update-nested-transform-and-nested-value.json
@@ -1,48 +1,52 @@
 {
-  "description": "update: Nested transforms should not affect the field mask, even\nwhen there are other values that do. Transforms should only affect the\nDocumentTransform_FieldTransform list.",
-  "comment": "For updates, top-level paths in json-like map inputs\nare split on the dot. That is, an input {\"a.b.c\": 7} results in an update to\nfield c of object b of object a with value 7. In order to specify this behavior,\nthe update must use a fieldmask \"a.b.c\". However, fieldmasks are only used for\nconcrete values - transforms are separately encoded in a\nDocumentTransform_FieldTransform array.\n\nThis test exercises a bug found in python (https://github.com/googleapis/google-cloud-python/issues/7215)\nin which nested transforms ({\"a.c\": \"ServerTimestamp\"}) next to nested values\n({\"a.b\": 7}) incorrectly caused the fieldmask \"a\" to be set, which has the\neffect of wiping out all data in \"a\" other than what was specified in the\njson-like input.\n\nInstead, as this test specifies, transforms should not affect the fieldmask.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a.b\": 7, \"a.c\": \"ServerTimestamp\"}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "mapValue": {
-                  "fields": {
-                    "b": {
-                      "integerValue": "7"
+  "tests": [
+    {
+      "description": "update: Nested transforms should not affect the field mask, even\nwhen there are other values that do. Transforms should only affect the\nDocumentTransform_FieldTransform list.",
+      "comment": "For updates, top-level paths in json-like map inputs\nare split on the dot. That is, an input {\"a.b.c\": 7} results in an update to\nfield c of object b of object a with value 7. In order to specify this behavior,\nthe update must use a fieldmask \"a.b.c\". However, fieldmasks are only used for\nconcrete values - transforms are separately encoded in a\nDocumentTransform_FieldTransform array.\n\nThis test exercises a bug found in python (https://github.com/googleapis/google-cloud-python/issues/7215)\nin which nested transforms ({\"a.c\": \"ServerTimestamp\"}) next to nested values\n({\"a.b\": 7}) incorrectly caused the fieldmask \"a\" to be set, which has the\neffect of wiping out all data in \"a\" other than what was specified in the\njson-like input.\n\nInstead, as this test specifies, transforms should not affect the fieldmask.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a.b\": 7, \"a.c\": \"ServerTimestamp\"}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "mapValue": {
+                      "fields": {
+                        "b": {
+                          "integerValue": "7"
+                        }
+                      }
                     }
                   }
                 }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a.b"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "a.c",
+                    "setToServerValue": "REQUEST_TIME"
+                  }
+                ]
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "a.b"
-            ]
-          },
-          "currentDocument": {
-            "exists": true
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "a.c",
-                "setToServerValue": "REQUEST_TIME"
-              }
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-no-paths.json
+++ b/firestore/v1/testcase/update-no-paths.json
@@ -1,0 +1,9 @@
+{
+  "description": "update: no paths",
+  "comment": "It is a client-side error to call Update with empty data.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-no-paths.json
+++ b/firestore/v1/testcase/update-no-paths.json
@@ -1,9 +1,13 @@
 {
-  "description": "update: no paths",
-  "comment": "It is a client-side error to call Update with empty data.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "update: no paths",
+      "comment": "It is a client-side error to call Update with empty data.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-all-transforms.json
+++ b/firestore/v1/testcase/update-paths-all-transforms.json
@@ -1,0 +1,101 @@
+{
+  "description": "update-paths: all transforms in a single call",
+  "comment": "A document can be created with any amount of transforms.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      },
+      {
+        "field": [
+          "b"
+        ]
+      },
+      {
+        "field": [
+          "c"
+        ]
+      },
+      {
+        "field": [
+          "d"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "1",
+      "\"ServerTimestamp\"",
+      "[\"ArrayUnion\", 1, 2, 3]",
+      "[\"ArrayRemove\", 4, 5, 6]"
+    ],
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b",
+                "setToServerValue": "REQUEST_TIME"
+              },
+              {
+                "fieldPath": "c",
+                "appendMissingElements": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "integerValue": "2"
+                    },
+                    {
+                      "integerValue": "3"
+                    }
+                  ]
+                }
+              },
+              {
+                "fieldPath": "d",
+                "removeAllFromArray": {
+                  "values": [
+                    {
+                      "integerValue": "4"
+                    },
+                    {
+                      "integerValue": "5"
+                    },
+                    {
+                      "integerValue": "6"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-paths-all-transforms.json
+++ b/firestore/v1/testcase/update-paths-all-transforms.json
@@ -1,101 +1,105 @@
 {
-  "description": "update-paths: all transforms in a single call",
-  "comment": "A document can be created with any amount of transforms.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
-      },
-      {
-        "field": [
-          "b"
-        ]
-      },
-      {
-        "field": [
-          "c"
-        ]
-      },
-      {
-        "field": [
-          "d"
-        ]
-      }
-    ],
-    "jsonValues": [
-      "1",
-      "\"ServerTimestamp\"",
-      "[\"ArrayUnion\", 1, 2, 3]",
-      "[\"ArrayRemove\", 4, 5, 6]"
-    ],
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            }
-          },
-          "updateMask": {
-            "fieldPaths": [
+  "tests": [
+    {
+      "description": "update-paths: all transforms in a single call",
+      "comment": "A document can be created with any amount of transforms.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
               "a"
             ]
           },
-          "currentDocument": {
-            "exists": true
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b",
-                "setToServerValue": "REQUEST_TIME"
-              },
-              {
-                "fieldPath": "c",
-                "appendMissingElements": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "integerValue": "2"
-                    },
-                    {
-                      "integerValue": "3"
-                    }
-                  ]
-                }
-              },
-              {
-                "fieldPath": "d",
-                "removeAllFromArray": {
-                  "values": [
-                    {
-                      "integerValue": "4"
-                    },
-                    {
-                      "integerValue": "5"
-                    },
-                    {
-                      "integerValue": "6"
-                    }
-                  ]
-                }
-              }
+          {
+            "field": [
+              "b"
+            ]
+          },
+          {
+            "field": [
+              "c"
+            ]
+          },
+          {
+            "field": [
+              "d"
             ]
           }
+        ],
+        "jsonValues": [
+          "1",
+          "\"ServerTimestamp\"",
+          "[\"ArrayUnion\", 1, 2, 3]",
+          "[\"ArrayRemove\", 4, 5, 6]"
+        ],
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b",
+                    "setToServerValue": "REQUEST_TIME"
+                  },
+                  {
+                    "fieldPath": "c",
+                    "appendMissingElements": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "integerValue": "2"
+                        },
+                        {
+                          "integerValue": "3"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "fieldPath": "d",
+                    "removeAllFromArray": {
+                      "values": [
+                        {
+                          "integerValue": "4"
+                        },
+                        {
+                          "integerValue": "5"
+                        },
+                        {
+                          "integerValue": "6"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-arrayremove-alone.json
+++ b/firestore/v1/testcase/update-paths-arrayremove-alone.json
@@ -1,0 +1,48 @@
+{
+  "description": "update-paths: ArrayRemove alone",
+  "comment": "If the only values in the input are ArrayRemove, then no\nupdate operation should be produced.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "[\"ArrayRemove\", 1, 2, 3]"
+    ],
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "a",
+                "removeAllFromArray": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "integerValue": "2"
+                    },
+                    {
+                      "integerValue": "3"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-paths-arrayremove-alone.json
+++ b/firestore/v1/testcase/update-paths-arrayremove-alone.json
@@ -1,48 +1,52 @@
 {
-  "description": "update-paths: ArrayRemove alone",
-  "comment": "If the only values in the input are ArrayRemove, then no\nupdate operation should be produced.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
-      }
-    ],
-    "jsonValues": [
-      "[\"ArrayRemove\", 1, 2, 3]"
-    ],
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "a",
-                "removeAllFromArray": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "integerValue": "2"
-                    },
-                    {
-                      "integerValue": "3"
-                    }
-                  ]
-                }
-              }
+  "tests": [
+    {
+      "description": "update-paths: ArrayRemove alone",
+      "comment": "If the only values in the input are ArrayRemove, then no\nupdate operation should be produced.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
+              "a"
             ]
-          },
-          "currentDocument": {
-            "exists": true
           }
+        ],
+        "jsonValues": [
+          "[\"ArrayRemove\", 1, 2, 3]"
+        ],
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "a",
+                    "removeAllFromArray": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "integerValue": "2"
+                        },
+                        {
+                          "integerValue": "3"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "currentDocument": {
+                "exists": true
+              }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-arrayremove-multi.json
+++ b/firestore/v1/testcase/update-paths-arrayremove-multi.json
@@ -1,0 +1,92 @@
+{
+  "description": "update-paths: multiple ArrayRemove fields",
+  "comment": "A document can have more than one ArrayRemove field.\nSince all the ArrayRemove fields are removed, the only field in the update is \"a\".",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      },
+      {
+        "field": [
+          "b"
+        ]
+      },
+      {
+        "field": [
+          "c"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "1",
+      "[\"ArrayRemove\", 1, 2, 3]",
+      "{\"d\": [\"ArrayRemove\", 4, 5, 6]}"
+    ],
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a",
+              "c"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b",
+                "removeAllFromArray": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "integerValue": "2"
+                    },
+                    {
+                      "integerValue": "3"
+                    }
+                  ]
+                }
+              },
+              {
+                "fieldPath": "c.d",
+                "removeAllFromArray": {
+                  "values": [
+                    {
+                      "integerValue": "4"
+                    },
+                    {
+                      "integerValue": "5"
+                    },
+                    {
+                      "integerValue": "6"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-paths-arrayremove-multi.json
+++ b/firestore/v1/testcase/update-paths-arrayremove-multi.json
@@ -1,92 +1,96 @@
 {
-  "description": "update-paths: multiple ArrayRemove fields",
-  "comment": "A document can have more than one ArrayRemove field.\nSince all the ArrayRemove fields are removed, the only field in the update is \"a\".",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
-      },
-      {
-        "field": [
-          "b"
-        ]
-      },
-      {
-        "field": [
-          "c"
-        ]
-      }
-    ],
-    "jsonValues": [
-      "1",
-      "[\"ArrayRemove\", 1, 2, 3]",
-      "{\"d\": [\"ArrayRemove\", 4, 5, 6]}"
-    ],
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            }
+  "tests": [
+    {
+      "description": "update-paths: multiple ArrayRemove fields",
+      "comment": "A document can have more than one ArrayRemove field.\nSince all the ArrayRemove fields are removed, the only field in the update is \"a\".",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
+              "a"
+            ]
           },
-          "updateMask": {
-            "fieldPaths": [
-              "a",
+          {
+            "field": [
+              "b"
+            ]
+          },
+          {
+            "field": [
               "c"
             ]
-          },
-          "currentDocument": {
-            "exists": true
           }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b",
-                "removeAllFromArray": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "integerValue": "2"
-                    },
-                    {
-                      "integerValue": "3"
-                    }
-                  ]
+        ],
+        "jsonValues": [
+          "1",
+          "[\"ArrayRemove\", 1, 2, 3]",
+          "{\"d\": [\"ArrayRemove\", 4, 5, 6]}"
+        ],
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
                 }
               },
-              {
-                "fieldPath": "c.d",
-                "removeAllFromArray": {
-                  "values": [
-                    {
-                      "integerValue": "4"
-                    },
-                    {
-                      "integerValue": "5"
-                    },
-                    {
-                      "integerValue": "6"
-                    }
-                  ]
-                }
+              "updateMask": {
+                "fieldPaths": [
+                  "a",
+                  "c"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
               }
-            ]
-          }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b",
+                    "removeAllFromArray": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "integerValue": "2"
+                        },
+                        {
+                          "integerValue": "3"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "fieldPath": "c.d",
+                    "removeAllFromArray": {
+                      "values": [
+                        {
+                          "integerValue": "4"
+                        },
+                        {
+                          "integerValue": "5"
+                        },
+                        {
+                          "integerValue": "6"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-arrayremove-nested.json
+++ b/firestore/v1/testcase/update-paths-arrayremove-nested.json
@@ -1,0 +1,70 @@
+{
+  "description": "update-paths: nested ArrayRemove field",
+  "comment": "An ArrayRemove value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      },
+      {
+        "field": [
+          "b"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "1",
+      "{\"c\": [\"ArrayRemove\", 1, 2, 3]}"
+    ],
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a",
+              "b"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b.c",
+                "removeAllFromArray": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "integerValue": "2"
+                    },
+                    {
+                      "integerValue": "3"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-paths-arrayremove-nested.json
+++ b/firestore/v1/testcase/update-paths-arrayremove-nested.json
@@ -1,70 +1,74 @@
 {
-  "description": "update-paths: nested ArrayRemove field",
-  "comment": "An ArrayRemove value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
-      },
-      {
-        "field": [
-          "b"
-        ]
-      }
-    ],
-    "jsonValues": [
-      "1",
-      "{\"c\": [\"ArrayRemove\", 1, 2, 3]}"
-    ],
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            }
+  "tests": [
+    {
+      "description": "update-paths: nested ArrayRemove field",
+      "comment": "An ArrayRemove value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
+              "a"
+            ]
           },
-          "updateMask": {
-            "fieldPaths": [
-              "a",
+          {
+            "field": [
               "b"
             ]
-          },
-          "currentDocument": {
-            "exists": true
           }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b.c",
-                "removeAllFromArray": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "integerValue": "2"
-                    },
-                    {
-                      "integerValue": "3"
-                    }
-                  ]
+        ],
+        "jsonValues": [
+          "1",
+          "{\"c\": [\"ArrayRemove\", 1, 2, 3]}"
+        ],
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
                 }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a",
+                  "b"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
               }
-            ]
-          }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b.c",
+                    "removeAllFromArray": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "integerValue": "2"
+                        },
+                        {
+                          "integerValue": "3"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-arrayremove-noarray-nested.json
+++ b/firestore/v1/testcase/update-paths-arrayremove-noarray-nested.json
@@ -1,0 +1,18 @@
+{
+  "description": "update-paths: ArrayRemove cannot be anywhere inside an array value",
+  "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ArrayRemove. Firestore transforms don't support array indexing.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "[1, {\"b\": [\"ArrayRemove\", 1, 2, 3]}]"
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-paths-arrayremove-noarray-nested.json
+++ b/firestore/v1/testcase/update-paths-arrayremove-noarray-nested.json
@@ -1,18 +1,22 @@
 {
-  "description": "update-paths: ArrayRemove cannot be anywhere inside an array value",
-  "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ArrayRemove. Firestore transforms don't support array indexing.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
+  "tests": [
+    {
+      "description": "update-paths: ArrayRemove cannot be anywhere inside an array value",
+      "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ArrayRemove. Firestore transforms don't support array indexing.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
+              "a"
+            ]
+          }
+        ],
+        "jsonValues": [
+          "[1, {\"b\": [\"ArrayRemove\", 1, 2, 3]}]"
+        ],
+        "isError": true
       }
-    ],
-    "jsonValues": [
-      "[1, {\"b\": [\"ArrayRemove\", 1, 2, 3]}]"
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-arrayremove-noarray.json
+++ b/firestore/v1/testcase/update-paths-arrayremove-noarray.json
@@ -1,0 +1,18 @@
+{
+  "description": "update-paths: ArrayRemove cannot be in an array value",
+  "comment": "ArrayRemove must be the value of a field. Firestore\ntransforms don't support array indexing.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "[1, 2, [\"ArrayRemove\", 1, 2, 3]]"
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-paths-arrayremove-noarray.json
+++ b/firestore/v1/testcase/update-paths-arrayremove-noarray.json
@@ -1,18 +1,22 @@
 {
-  "description": "update-paths: ArrayRemove cannot be in an array value",
-  "comment": "ArrayRemove must be the value of a field. Firestore\ntransforms don't support array indexing.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
+  "tests": [
+    {
+      "description": "update-paths: ArrayRemove cannot be in an array value",
+      "comment": "ArrayRemove must be the value of a field. Firestore\ntransforms don't support array indexing.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
+              "a"
+            ]
+          }
+        ],
+        "jsonValues": [
+          "[1, 2, [\"ArrayRemove\", 1, 2, 3]]"
+        ],
+        "isError": true
       }
-    ],
-    "jsonValues": [
-      "[1, 2, [\"ArrayRemove\", 1, 2, 3]]"
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-arrayremove-with-st.json
+++ b/firestore/v1/testcase/update-paths-arrayremove-with-st.json
@@ -1,0 +1,18 @@
+{
+  "description": "update-paths: The ServerTimestamp sentinel cannot be in an ArrayUnion",
+  "comment": "The ServerTimestamp sentinel must be the value of a field. It may\nnot appear in an ArrayUnion.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "[\"ArrayRemove\", 1, \"ServerTimestamp\", 3]"
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-paths-arrayremove-with-st.json
+++ b/firestore/v1/testcase/update-paths-arrayremove-with-st.json
@@ -1,18 +1,22 @@
 {
-  "description": "update-paths: The ServerTimestamp sentinel cannot be in an ArrayUnion",
-  "comment": "The ServerTimestamp sentinel must be the value of a field. It may\nnot appear in an ArrayUnion.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
+  "tests": [
+    {
+      "description": "update-paths: The ServerTimestamp sentinel cannot be in an ArrayUnion",
+      "comment": "The ServerTimestamp sentinel must be the value of a field. It may\nnot appear in an ArrayUnion.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
+              "a"
+            ]
+          }
+        ],
+        "jsonValues": [
+          "[\"ArrayRemove\", 1, \"ServerTimestamp\", 3]"
+        ],
+        "isError": true
       }
-    ],
-    "jsonValues": [
-      "[\"ArrayRemove\", 1, \"ServerTimestamp\", 3]"
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-arrayremove.json
+++ b/firestore/v1/testcase/update-paths-arrayremove.json
@@ -1,0 +1,69 @@
+{
+  "description": "update-paths: ArrayRemove with data",
+  "comment": "A key with ArrayRemove is removed from the data in the update \noperation. Instead it appears in a separate Transform operation.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      },
+      {
+        "field": [
+          "b"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "1",
+      "[\"ArrayRemove\", 1, 2, 3]"
+    ],
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b",
+                "removeAllFromArray": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "integerValue": "2"
+                    },
+                    {
+                      "integerValue": "3"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-paths-arrayremove.json
+++ b/firestore/v1/testcase/update-paths-arrayremove.json
@@ -1,69 +1,73 @@
 {
-  "description": "update-paths: ArrayRemove with data",
-  "comment": "A key with ArrayRemove is removed from the data in the update \noperation. Instead it appears in a separate Transform operation.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
-      },
-      {
-        "field": [
-          "b"
-        ]
-      }
-    ],
-    "jsonValues": [
-      "1",
-      "[\"ArrayRemove\", 1, 2, 3]"
-    ],
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            }
-          },
-          "updateMask": {
-            "fieldPaths": [
+  "tests": [
+    {
+      "description": "update-paths: ArrayRemove with data",
+      "comment": "A key with ArrayRemove is removed from the data in the update \noperation. Instead it appears in a separate Transform operation.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
               "a"
             ]
           },
-          "currentDocument": {
-            "exists": true
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b",
-                "removeAllFromArray": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "integerValue": "2"
-                    },
-                    {
-                      "integerValue": "3"
-                    }
-                  ]
-                }
-              }
+          {
+            "field": [
+              "b"
             ]
           }
+        ],
+        "jsonValues": [
+          "1",
+          "[\"ArrayRemove\", 1, 2, 3]"
+        ],
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b",
+                    "removeAllFromArray": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "integerValue": "2"
+                        },
+                        {
+                          "integerValue": "3"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-arrayunion-alone.json
+++ b/firestore/v1/testcase/update-paths-arrayunion-alone.json
@@ -1,0 +1,48 @@
+{
+  "description": "update-paths: ArrayUnion alone",
+  "comment": "If the only values in the input are ArrayUnion, then no\nupdate operation should be produced.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "[\"ArrayUnion\", 1, 2, 3]"
+    ],
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "a",
+                "appendMissingElements": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "integerValue": "2"
+                    },
+                    {
+                      "integerValue": "3"
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-paths-arrayunion-alone.json
+++ b/firestore/v1/testcase/update-paths-arrayunion-alone.json
@@ -1,48 +1,52 @@
 {
-  "description": "update-paths: ArrayUnion alone",
-  "comment": "If the only values in the input are ArrayUnion, then no\nupdate operation should be produced.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
-      }
-    ],
-    "jsonValues": [
-      "[\"ArrayUnion\", 1, 2, 3]"
-    ],
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "a",
-                "appendMissingElements": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "integerValue": "2"
-                    },
-                    {
-                      "integerValue": "3"
-                    }
-                  ]
-                }
-              }
+  "tests": [
+    {
+      "description": "update-paths: ArrayUnion alone",
+      "comment": "If the only values in the input are ArrayUnion, then no\nupdate operation should be produced.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
+              "a"
             ]
-          },
-          "currentDocument": {
-            "exists": true
           }
+        ],
+        "jsonValues": [
+          "[\"ArrayUnion\", 1, 2, 3]"
+        ],
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "a",
+                    "appendMissingElements": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "integerValue": "2"
+                        },
+                        {
+                          "integerValue": "3"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              "currentDocument": {
+                "exists": true
+              }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-arrayunion-multi.json
+++ b/firestore/v1/testcase/update-paths-arrayunion-multi.json
@@ -1,0 +1,92 @@
+{
+  "description": "update-paths: multiple ArrayUnion fields",
+  "comment": "A document can have more than one ArrayUnion field.\nSince all the ArrayUnion fields are removed, the only field in the update is \"a\".",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      },
+      {
+        "field": [
+          "b"
+        ]
+      },
+      {
+        "field": [
+          "c"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "1",
+      "[\"ArrayUnion\", 1, 2, 3]",
+      "{\"d\": [\"ArrayUnion\", 4, 5, 6]}"
+    ],
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a",
+              "c"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b",
+                "appendMissingElements": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "integerValue": "2"
+                    },
+                    {
+                      "integerValue": "3"
+                    }
+                  ]
+                }
+              },
+              {
+                "fieldPath": "c.d",
+                "appendMissingElements": {
+                  "values": [
+                    {
+                      "integerValue": "4"
+                    },
+                    {
+                      "integerValue": "5"
+                    },
+                    {
+                      "integerValue": "6"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-paths-arrayunion-multi.json
+++ b/firestore/v1/testcase/update-paths-arrayunion-multi.json
@@ -1,92 +1,96 @@
 {
-  "description": "update-paths: multiple ArrayUnion fields",
-  "comment": "A document can have more than one ArrayUnion field.\nSince all the ArrayUnion fields are removed, the only field in the update is \"a\".",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
-      },
-      {
-        "field": [
-          "b"
-        ]
-      },
-      {
-        "field": [
-          "c"
-        ]
-      }
-    ],
-    "jsonValues": [
-      "1",
-      "[\"ArrayUnion\", 1, 2, 3]",
-      "{\"d\": [\"ArrayUnion\", 4, 5, 6]}"
-    ],
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            }
+  "tests": [
+    {
+      "description": "update-paths: multiple ArrayUnion fields",
+      "comment": "A document can have more than one ArrayUnion field.\nSince all the ArrayUnion fields are removed, the only field in the update is \"a\".",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
+              "a"
+            ]
           },
-          "updateMask": {
-            "fieldPaths": [
-              "a",
+          {
+            "field": [
+              "b"
+            ]
+          },
+          {
+            "field": [
               "c"
             ]
-          },
-          "currentDocument": {
-            "exists": true
           }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b",
-                "appendMissingElements": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "integerValue": "2"
-                    },
-                    {
-                      "integerValue": "3"
-                    }
-                  ]
+        ],
+        "jsonValues": [
+          "1",
+          "[\"ArrayUnion\", 1, 2, 3]",
+          "{\"d\": [\"ArrayUnion\", 4, 5, 6]}"
+        ],
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
                 }
               },
-              {
-                "fieldPath": "c.d",
-                "appendMissingElements": {
-                  "values": [
-                    {
-                      "integerValue": "4"
-                    },
-                    {
-                      "integerValue": "5"
-                    },
-                    {
-                      "integerValue": "6"
-                    }
-                  ]
-                }
+              "updateMask": {
+                "fieldPaths": [
+                  "a",
+                  "c"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
               }
-            ]
-          }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b",
+                    "appendMissingElements": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "integerValue": "2"
+                        },
+                        {
+                          "integerValue": "3"
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "fieldPath": "c.d",
+                    "appendMissingElements": {
+                      "values": [
+                        {
+                          "integerValue": "4"
+                        },
+                        {
+                          "integerValue": "5"
+                        },
+                        {
+                          "integerValue": "6"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-arrayunion-nested.json
+++ b/firestore/v1/testcase/update-paths-arrayunion-nested.json
@@ -1,0 +1,70 @@
+{
+  "description": "update-paths: nested ArrayUnion field",
+  "comment": "An ArrayUnion value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      },
+      {
+        "field": [
+          "b"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "1",
+      "{\"c\": [\"ArrayUnion\", 1, 2, 3]}"
+    ],
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a",
+              "b"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b.c",
+                "appendMissingElements": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "integerValue": "2"
+                    },
+                    {
+                      "integerValue": "3"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-paths-arrayunion-nested.json
+++ b/firestore/v1/testcase/update-paths-arrayunion-nested.json
@@ -1,70 +1,74 @@
 {
-  "description": "update-paths: nested ArrayUnion field",
-  "comment": "An ArrayUnion value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
-      },
-      {
-        "field": [
-          "b"
-        ]
-      }
-    ],
-    "jsonValues": [
-      "1",
-      "{\"c\": [\"ArrayUnion\", 1, 2, 3]}"
-    ],
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            }
+  "tests": [
+    {
+      "description": "update-paths: nested ArrayUnion field",
+      "comment": "An ArrayUnion value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
+              "a"
+            ]
           },
-          "updateMask": {
-            "fieldPaths": [
-              "a",
+          {
+            "field": [
               "b"
             ]
-          },
-          "currentDocument": {
-            "exists": true
           }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b.c",
-                "appendMissingElements": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "integerValue": "2"
-                    },
-                    {
-                      "integerValue": "3"
-                    }
-                  ]
+        ],
+        "jsonValues": [
+          "1",
+          "{\"c\": [\"ArrayUnion\", 1, 2, 3]}"
+        ],
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
                 }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a",
+                  "b"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
               }
-            ]
-          }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b.c",
+                    "appendMissingElements": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "integerValue": "2"
+                        },
+                        {
+                          "integerValue": "3"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-arrayunion-noarray-nested.json
+++ b/firestore/v1/testcase/update-paths-arrayunion-noarray-nested.json
@@ -1,0 +1,18 @@
+{
+  "description": "update-paths: ArrayUnion cannot be anywhere inside an array value",
+  "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ArrayUnion. Firestore transforms don't support array indexing.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "[1, {\"b\": [\"ArrayUnion\", 1, 2, 3]}]"
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-paths-arrayunion-noarray-nested.json
+++ b/firestore/v1/testcase/update-paths-arrayunion-noarray-nested.json
@@ -1,18 +1,22 @@
 {
-  "description": "update-paths: ArrayUnion cannot be anywhere inside an array value",
-  "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ArrayUnion. Firestore transforms don't support array indexing.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
+  "tests": [
+    {
+      "description": "update-paths: ArrayUnion cannot be anywhere inside an array value",
+      "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ArrayUnion. Firestore transforms don't support array indexing.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
+              "a"
+            ]
+          }
+        ],
+        "jsonValues": [
+          "[1, {\"b\": [\"ArrayUnion\", 1, 2, 3]}]"
+        ],
+        "isError": true
       }
-    ],
-    "jsonValues": [
-      "[1, {\"b\": [\"ArrayUnion\", 1, 2, 3]}]"
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-arrayunion-noarray.json
+++ b/firestore/v1/testcase/update-paths-arrayunion-noarray.json
@@ -1,0 +1,18 @@
+{
+  "description": "update-paths: ArrayUnion cannot be in an array value",
+  "comment": "ArrayUnion must be the value of a field. Firestore\ntransforms don't support array indexing.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "[1, 2, [\"ArrayRemove\", 1, 2, 3]]"
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-paths-arrayunion-noarray.json
+++ b/firestore/v1/testcase/update-paths-arrayunion-noarray.json
@@ -1,18 +1,22 @@
 {
-  "description": "update-paths: ArrayUnion cannot be in an array value",
-  "comment": "ArrayUnion must be the value of a field. Firestore\ntransforms don't support array indexing.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
+  "tests": [
+    {
+      "description": "update-paths: ArrayUnion cannot be in an array value",
+      "comment": "ArrayUnion must be the value of a field. Firestore\ntransforms don't support array indexing.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
+              "a"
+            ]
+          }
+        ],
+        "jsonValues": [
+          "[1, 2, [\"ArrayRemove\", 1, 2, 3]]"
+        ],
+        "isError": true
       }
-    ],
-    "jsonValues": [
-      "[1, 2, [\"ArrayRemove\", 1, 2, 3]]"
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-arrayunion-with-st.json
+++ b/firestore/v1/testcase/update-paths-arrayunion-with-st.json
@@ -1,0 +1,18 @@
+{
+  "description": "update-paths: The ServerTimestamp sentinel cannot be in an ArrayUnion",
+  "comment": "The ServerTimestamp sentinel must be the value of a field. It may\nnot appear in an ArrayUnion.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "[\"ArrayUnion\", 1, \"ServerTimestamp\", 3]"
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-paths-arrayunion-with-st.json
+++ b/firestore/v1/testcase/update-paths-arrayunion-with-st.json
@@ -1,18 +1,22 @@
 {
-  "description": "update-paths: The ServerTimestamp sentinel cannot be in an ArrayUnion",
-  "comment": "The ServerTimestamp sentinel must be the value of a field. It may\nnot appear in an ArrayUnion.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
+  "tests": [
+    {
+      "description": "update-paths: The ServerTimestamp sentinel cannot be in an ArrayUnion",
+      "comment": "The ServerTimestamp sentinel must be the value of a field. It may\nnot appear in an ArrayUnion.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
+              "a"
+            ]
+          }
+        ],
+        "jsonValues": [
+          "[\"ArrayUnion\", 1, \"ServerTimestamp\", 3]"
+        ],
+        "isError": true
       }
-    ],
-    "jsonValues": [
-      "[\"ArrayUnion\", 1, \"ServerTimestamp\", 3]"
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-arrayunion.json
+++ b/firestore/v1/testcase/update-paths-arrayunion.json
@@ -1,0 +1,69 @@
+{
+  "description": "update-paths: ArrayUnion with data",
+  "comment": "A key with ArrayUnion is removed from the data in the update \noperation. Instead it appears in a separate Transform operation.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      },
+      {
+        "field": [
+          "b"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "1",
+      "[\"ArrayUnion\", 1, 2, 3]"
+    ],
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b",
+                "appendMissingElements": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "integerValue": "2"
+                    },
+                    {
+                      "integerValue": "3"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-paths-arrayunion.json
+++ b/firestore/v1/testcase/update-paths-arrayunion.json
@@ -1,69 +1,73 @@
 {
-  "description": "update-paths: ArrayUnion with data",
-  "comment": "A key with ArrayUnion is removed from the data in the update \noperation. Instead it appears in a separate Transform operation.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
-      },
-      {
-        "field": [
-          "b"
-        ]
-      }
-    ],
-    "jsonValues": [
-      "1",
-      "[\"ArrayUnion\", 1, 2, 3]"
-    ],
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            }
-          },
-          "updateMask": {
-            "fieldPaths": [
+  "tests": [
+    {
+      "description": "update-paths: ArrayUnion with data",
+      "comment": "A key with ArrayUnion is removed from the data in the update \noperation. Instead it appears in a separate Transform operation.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
               "a"
             ]
           },
-          "currentDocument": {
-            "exists": true
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b",
-                "appendMissingElements": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "integerValue": "2"
-                    },
-                    {
-                      "integerValue": "3"
-                    }
-                  ]
-                }
-              }
+          {
+            "field": [
+              "b"
             ]
           }
+        ],
+        "jsonValues": [
+          "1",
+          "[\"ArrayUnion\", 1, 2, 3]"
+        ],
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b",
+                    "appendMissingElements": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "integerValue": "2"
+                        },
+                        {
+                          "integerValue": "3"
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-basic.json
+++ b/firestore/v1/testcase/update-paths-basic.json
@@ -1,0 +1,40 @@
+{
+  "description": "update-paths: basic",
+  "comment": "A simple call, resulting in a single update operation.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "1"
+    ],
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-paths-basic.json
+++ b/firestore/v1/testcase/update-paths-basic.json
@@ -1,40 +1,44 @@
 {
-  "description": "update-paths: basic",
-  "comment": "A simple call, resulting in a single update operation.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
-      }
-    ],
-    "jsonValues": [
-      "1"
-    ],
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            }
-          },
-          "updateMask": {
-            "fieldPaths": [
+  "tests": [
+    {
+      "description": "update-paths: basic",
+      "comment": "A simple call, resulting in a single update operation.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
               "a"
             ]
-          },
-          "currentDocument": {
-            "exists": true
           }
+        ],
+        "jsonValues": [
+          "1"
+        ],
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
+              }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-complex.json
+++ b/firestore/v1/testcase/update-paths-complex.json
@@ -1,0 +1,80 @@
+{
+  "description": "update-paths: complex",
+  "comment": "A call to a write method with complicated input data.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      },
+      {
+        "field": [
+          "b"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "[1, 2.5]",
+      "{\"c\": [\"three\", {\"d\": true}]}"
+    ],
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "arrayValue": {
+                  "values": [
+                    {
+                      "integerValue": "1"
+                    },
+                    {
+                      "doubleValue": 2.5
+                    }
+                  ]
+                }
+              },
+              "b": {
+                "mapValue": {
+                  "fields": {
+                    "c": {
+                      "arrayValue": {
+                        "values": [
+                          {
+                            "stringValue": "three"
+                          },
+                          {
+                            "mapValue": {
+                              "fields": {
+                                "d": {
+                                  "booleanValue": true
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a",
+              "b"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-paths-complex.json
+++ b/firestore/v1/testcase/update-paths-complex.json
@@ -1,80 +1,84 @@
 {
-  "description": "update-paths: complex",
-  "comment": "A call to a write method with complicated input data.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
-      },
-      {
-        "field": [
-          "b"
-        ]
-      }
-    ],
-    "jsonValues": [
-      "[1, 2.5]",
-      "{\"c\": [\"three\", {\"d\": true}]}"
-    ],
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "arrayValue": {
-                  "values": [
-                    {
-                      "integerValue": "1"
-                    },
-                    {
-                      "doubleValue": 2.5
+  "tests": [
+    {
+      "description": "update-paths: complex",
+      "comment": "A call to a write method with complicated input data.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
+              "a"
+            ]
+          },
+          {
+            "field": [
+              "b"
+            ]
+          }
+        ],
+        "jsonValues": [
+          "[1, 2.5]",
+          "{\"c\": [\"three\", {\"d\": true}]}"
+        ],
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "arrayValue": {
+                      "values": [
+                        {
+                          "integerValue": "1"
+                        },
+                        {
+                          "doubleValue": 2.5
+                        }
+                      ]
                     }
-                  ]
-                }
-              },
-              "b": {
-                "mapValue": {
-                  "fields": {
-                    "c": {
-                      "arrayValue": {
-                        "values": [
-                          {
-                            "stringValue": "three"
-                          },
-                          {
-                            "mapValue": {
-                              "fields": {
-                                "d": {
-                                  "booleanValue": true
+                  },
+                  "b": {
+                    "mapValue": {
+                      "fields": {
+                        "c": {
+                          "arrayValue": {
+                            "values": [
+                              {
+                                "stringValue": "three"
+                              },
+                              {
+                                "mapValue": {
+                                  "fields": {
+                                    "d": {
+                                      "booleanValue": true
+                                    }
+                                  }
                                 }
                               }
-                            }
+                            ]
                           }
-                        ]
+                        }
                       }
                     }
                   }
                 }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a",
+                  "b"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "a",
-              "b"
-            ]
-          },
-          "currentDocument": {
-            "exists": true
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-del-alone.json
+++ b/firestore/v1/testcase/update-paths-del-alone.json
@@ -1,0 +1,35 @@
+{
+  "description": "update-paths: Delete alone",
+  "comment": "If the input data consists solely of Deletes, then the update\noperation has no map, just an update mask.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "\"Delete\""
+    ],
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d"
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-paths-del-alone.json
+++ b/firestore/v1/testcase/update-paths-del-alone.json
@@ -1,35 +1,39 @@
 {
-  "description": "update-paths: Delete alone",
-  "comment": "If the input data consists solely of Deletes, then the update\noperation has no map, just an update mask.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
-      }
-    ],
-    "jsonValues": [
-      "\"Delete\""
-    ],
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d"
-          },
-          "updateMask": {
-            "fieldPaths": [
+  "tests": [
+    {
+      "description": "update-paths: Delete alone",
+      "comment": "If the input data consists solely of Deletes, then the update\noperation has no map, just an update mask.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
               "a"
             ]
-          },
-          "currentDocument": {
-            "exists": true
           }
+        ],
+        "jsonValues": [
+          "\"Delete\""
+        ],
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d"
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
+              }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-del-nested.json
+++ b/firestore/v1/testcase/update-paths-del-nested.json
@@ -1,0 +1,18 @@
+{
+  "description": "update-paths: Delete cannot be nested",
+  "comment": "The Delete sentinel must be the value of a top-level key.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "{\"b\": \"Delete\"}"
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-paths-del-nested.json
+++ b/firestore/v1/testcase/update-paths-del-nested.json
@@ -1,18 +1,22 @@
 {
-  "description": "update-paths: Delete cannot be nested",
-  "comment": "The Delete sentinel must be the value of a top-level key.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
+  "tests": [
+    {
+      "description": "update-paths: Delete cannot be nested",
+      "comment": "The Delete sentinel must be the value of a top-level key.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
+              "a"
+            ]
+          }
+        ],
+        "jsonValues": [
+          "{\"b\": \"Delete\"}"
+        ],
+        "isError": true
       }
-    ],
-    "jsonValues": [
-      "{\"b\": \"Delete\"}"
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-del-noarray-nested.json
+++ b/firestore/v1/testcase/update-paths-del-noarray-nested.json
@@ -1,0 +1,18 @@
+{
+  "description": "update-paths: Delete cannot be anywhere inside an array value",
+  "comment": "The Delete sentinel must be the value of a field. Deletes are implemented\nby turning the path to the Delete sentinel into a FieldPath, and FieldPaths do not support\narray indexing.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "[1, {\"b\": \"Delete\"}]"
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-paths-del-noarray-nested.json
+++ b/firestore/v1/testcase/update-paths-del-noarray-nested.json
@@ -1,18 +1,22 @@
 {
-  "description": "update-paths: Delete cannot be anywhere inside an array value",
-  "comment": "The Delete sentinel must be the value of a field. Deletes are implemented\nby turning the path to the Delete sentinel into a FieldPath, and FieldPaths do not support\narray indexing.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
+  "tests": [
+    {
+      "description": "update-paths: Delete cannot be anywhere inside an array value",
+      "comment": "The Delete sentinel must be the value of a field. Deletes are implemented\nby turning the path to the Delete sentinel into a FieldPath, and FieldPaths do not support\narray indexing.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
+              "a"
+            ]
+          }
+        ],
+        "jsonValues": [
+          "[1, {\"b\": \"Delete\"}]"
+        ],
+        "isError": true
       }
-    ],
-    "jsonValues": [
-      "[1, {\"b\": \"Delete\"}]"
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-del-noarray.json
+++ b/firestore/v1/testcase/update-paths-del-noarray.json
@@ -1,0 +1,18 @@
+{
+  "description": "update-paths: Delete cannot be in an array value",
+  "comment": "The Delete sentinel must be the value of a field. Deletes are\nimplemented by turning the path to the Delete sentinel into a FieldPath, and FieldPaths\ndo not support array indexing.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "[1, 2, \"Delete\"]"
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-paths-del-noarray.json
+++ b/firestore/v1/testcase/update-paths-del-noarray.json
@@ -1,18 +1,22 @@
 {
-  "description": "update-paths: Delete cannot be in an array value",
-  "comment": "The Delete sentinel must be the value of a field. Deletes are\nimplemented by turning the path to the Delete sentinel into a FieldPath, and FieldPaths\ndo not support array indexing.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
+  "tests": [
+    {
+      "description": "update-paths: Delete cannot be in an array value",
+      "comment": "The Delete sentinel must be the value of a field. Deletes are\nimplemented by turning the path to the Delete sentinel into a FieldPath, and FieldPaths\ndo not support array indexing.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
+              "a"
+            ]
+          }
+        ],
+        "jsonValues": [
+          "[1, 2, \"Delete\"]"
+        ],
+        "isError": true
       }
-    ],
-    "jsonValues": [
-      "[1, 2, \"Delete\"]"
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-del.json
+++ b/firestore/v1/testcase/update-paths-del.json
@@ -1,0 +1,47 @@
+{
+  "description": "update-paths: Delete",
+  "comment": "If a field's value is the Delete sentinel, then it doesn't appear\nin the update data, but does in the mask.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      },
+      {
+        "field": [
+          "b"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "1",
+      "\"Delete\""
+    ],
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a",
+              "b"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-paths-del.json
+++ b/firestore/v1/testcase/update-paths-del.json
@@ -1,47 +1,51 @@
 {
-  "description": "update-paths: Delete",
-  "comment": "If a field's value is the Delete sentinel, then it doesn't appear\nin the update data, but does in the mask.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
-      },
-      {
-        "field": [
-          "b"
-        ]
-      }
-    ],
-    "jsonValues": [
-      "1",
-      "\"Delete\""
-    ],
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "a",
-              "b"
+  "tests": [
+    {
+      "description": "update-paths: Delete",
+      "comment": "If a field's value is the Delete sentinel, then it doesn't appear\nin the update data, but does in the mask.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
+              "a"
             ]
           },
-          "currentDocument": {
-            "exists": true
+          {
+            "field": [
+              "b"
+            ]
           }
+        ],
+        "jsonValues": [
+          "1",
+          "\"Delete\""
+        ],
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a",
+                  "b"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
+              }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-exists-precond.json
+++ b/firestore/v1/testcase/update-paths-exists-precond.json
@@ -1,0 +1,21 @@
+{
+  "description": "update-paths: Exists precondition is invalid",
+  "comment": "The Update method does not support an explicit exists precondition.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "precondition": {
+      "exists": true
+    },
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "1"
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-paths-exists-precond.json
+++ b/firestore/v1/testcase/update-paths-exists-precond.json
@@ -1,21 +1,25 @@
 {
-  "description": "update-paths: Exists precondition is invalid",
-  "comment": "The Update method does not support an explicit exists precondition.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "precondition": {
-      "exists": true
-    },
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
+  "tests": [
+    {
+      "description": "update-paths: Exists precondition is invalid",
+      "comment": "The Update method does not support an explicit exists precondition.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "precondition": {
+          "exists": true
+        },
+        "fieldPaths": [
+          {
+            "field": [
+              "a"
+            ]
+          }
+        ],
+        "jsonValues": [
+          "1"
+        ],
+        "isError": true
       }
-    ],
-    "jsonValues": [
-      "1"
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-fp-del.json
+++ b/firestore/v1/testcase/update-paths-fp-del.json
@@ -1,0 +1,55 @@
+{
+  "description": "update-paths: field paths with delete",
+  "comment": "If one nested field is deleted, and another isn't, preserve the second.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "foo",
+          "bar"
+        ]
+      },
+      {
+        "field": [
+          "foo",
+          "delete"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "1",
+      "\"Delete\""
+    ],
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "foo": {
+                "mapValue": {
+                  "fields": {
+                    "bar": {
+                      "integerValue": "1"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "foo.bar",
+              "foo.delete"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-paths-fp-del.json
+++ b/firestore/v1/testcase/update-paths-fp-del.json
@@ -1,55 +1,59 @@
 {
-  "description": "update-paths: field paths with delete",
-  "comment": "If one nested field is deleted, and another isn't, preserve the second.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "foo",
-          "bar"
-        ]
-      },
-      {
-        "field": [
-          "foo",
-          "delete"
-        ]
-      }
-    ],
-    "jsonValues": [
-      "1",
-      "\"Delete\""
-    ],
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "foo": {
-                "mapValue": {
-                  "fields": {
-                    "bar": {
-                      "integerValue": "1"
+  "tests": [
+    {
+      "description": "update-paths: field paths with delete",
+      "comment": "If one nested field is deleted, and another isn't, preserve the second.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
+              "foo",
+              "bar"
+            ]
+          },
+          {
+            "field": [
+              "foo",
+              "delete"
+            ]
+          }
+        ],
+        "jsonValues": [
+          "1",
+          "\"Delete\""
+        ],
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "foo": {
+                    "mapValue": {
+                      "fields": {
+                        "bar": {
+                          "integerValue": "1"
+                        }
+                      }
                     }
                   }
                 }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "foo.bar",
+                  "foo.delete"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "foo.bar",
-              "foo.delete"
-            ]
-          },
-          "currentDocument": {
-            "exists": true
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-fp-dup-transforms.json
+++ b/firestore/v1/testcase/update-paths-fp-dup-transforms.json
@@ -1,0 +1,30 @@
+{
+  "description": "update-paths: duplicate field path with only transforms",
+  "comment": "The same field cannot occur more than once, even if all the operations are transforms.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      },
+      {
+        "field": [
+          "b"
+        ]
+      },
+      {
+        "field": [
+          "a"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "[\"ArrayUnion\", 1, 2, 3]",
+      "\"ServerTimestamp\"",
+      "[\"ArrayUnion\", 4, 5, 6]"
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-paths-fp-dup-transforms.json
+++ b/firestore/v1/testcase/update-paths-fp-dup-transforms.json
@@ -1,30 +1,34 @@
 {
-  "description": "update-paths: duplicate field path with only transforms",
-  "comment": "The same field cannot occur more than once, even if all the operations are transforms.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
-      },
-      {
-        "field": [
-          "b"
-        ]
-      },
-      {
-        "field": [
-          "a"
-        ]
+  "tests": [
+    {
+      "description": "update-paths: duplicate field path with only transforms",
+      "comment": "The same field cannot occur more than once, even if all the operations are transforms.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
+              "a"
+            ]
+          },
+          {
+            "field": [
+              "b"
+            ]
+          },
+          {
+            "field": [
+              "a"
+            ]
+          }
+        ],
+        "jsonValues": [
+          "[\"ArrayUnion\", 1, 2, 3]",
+          "\"ServerTimestamp\"",
+          "[\"ArrayUnion\", 4, 5, 6]"
+        ],
+        "isError": true
       }
-    ],
-    "jsonValues": [
-      "[\"ArrayUnion\", 1, 2, 3]",
-      "\"ServerTimestamp\"",
-      "[\"ArrayUnion\", 4, 5, 6]"
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-fp-dup.json
+++ b/firestore/v1/testcase/update-paths-fp-dup.json
@@ -1,0 +1,30 @@
+{
+  "description": "update-paths: duplicate field path",
+  "comment": "The same field cannot occur more than once.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      },
+      {
+        "field": [
+          "b"
+        ]
+      },
+      {
+        "field": [
+          "a"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "1",
+      "2",
+      "3"
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-paths-fp-dup.json
+++ b/firestore/v1/testcase/update-paths-fp-dup.json
@@ -1,30 +1,34 @@
 {
-  "description": "update-paths: duplicate field path",
-  "comment": "The same field cannot occur more than once.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
-      },
-      {
-        "field": [
-          "b"
-        ]
-      },
-      {
-        "field": [
-          "a"
-        ]
+  "tests": [
+    {
+      "description": "update-paths: duplicate field path",
+      "comment": "The same field cannot occur more than once.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
+              "a"
+            ]
+          },
+          {
+            "field": [
+              "b"
+            ]
+          },
+          {
+            "field": [
+              "a"
+            ]
+          }
+        ],
+        "jsonValues": [
+          "1",
+          "2",
+          "3"
+        ],
+        "isError": true
       }
-    ],
-    "jsonValues": [
-      "1",
-      "2",
-      "3"
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-fp-empty-component.json
+++ b/firestore/v1/testcase/update-paths-fp-empty-component.json
@@ -1,0 +1,19 @@
+{
+  "description": "update-paths: empty field path component",
+  "comment": "Empty fields are not allowed.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "*",
+          ""
+        ]
+      }
+    ],
+    "jsonValues": [
+      "1"
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-paths-fp-empty-component.json
+++ b/firestore/v1/testcase/update-paths-fp-empty-component.json
@@ -1,19 +1,23 @@
 {
-  "description": "update-paths: empty field path component",
-  "comment": "Empty fields are not allowed.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "*",
-          ""
-        ]
+  "tests": [
+    {
+      "description": "update-paths: empty field path component",
+      "comment": "Empty fields are not allowed.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
+              "*",
+              ""
+            ]
+          }
+        ],
+        "jsonValues": [
+          "1"
+        ],
+        "isError": true
       }
-    ],
-    "jsonValues": [
-      "1"
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-fp-empty.json
+++ b/firestore/v1/testcase/update-paths-fp-empty.json
@@ -1,0 +1,16 @@
+{
+  "description": "update-paths: empty field path",
+  "comment": "A FieldPath of length zero is invalid.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": []
+      }
+    ],
+    "jsonValues": [
+      "1"
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-paths-fp-empty.json
+++ b/firestore/v1/testcase/update-paths-fp-empty.json
@@ -1,16 +1,20 @@
 {
-  "description": "update-paths: empty field path",
-  "comment": "A FieldPath of length zero is invalid.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": []
+  "tests": [
+    {
+      "description": "update-paths: empty field path",
+      "comment": "A FieldPath of length zero is invalid.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": []
+          }
+        ],
+        "jsonValues": [
+          "1"
+        ],
+        "isError": true
       }
-    ],
-    "jsonValues": [
-      "1"
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-fp-multi.json
+++ b/firestore/v1/testcase/update-paths-fp-multi.json
@@ -1,0 +1,47 @@
+{
+  "description": "update-paths: multiple-element field path",
+  "comment": "The UpdatePaths or equivalent method takes a list of FieldPaths.\nEach FieldPath is a sequence of uninterpreted path components.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a",
+          "b"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "1"
+    ],
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "mapValue": {
+                  "fields": {
+                    "b": {
+                      "integerValue": "1"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a.b"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-paths-fp-multi.json
+++ b/firestore/v1/testcase/update-paths-fp-multi.json
@@ -1,47 +1,51 @@
 {
-  "description": "update-paths: multiple-element field path",
-  "comment": "The UpdatePaths or equivalent method takes a list of FieldPaths.\nEach FieldPath is a sequence of uninterpreted path components.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a",
-          "b"
-        ]
-      }
-    ],
-    "jsonValues": [
-      "1"
-    ],
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "mapValue": {
-                  "fields": {
-                    "b": {
-                      "integerValue": "1"
+  "tests": [
+    {
+      "description": "update-paths: multiple-element field path",
+      "comment": "The UpdatePaths or equivalent method takes a list of FieldPaths.\nEach FieldPath is a sequence of uninterpreted path components.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
+              "a",
+              "b"
+            ]
+          }
+        ],
+        "jsonValues": [
+          "1"
+        ],
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "mapValue": {
+                      "fields": {
+                        "b": {
+                          "integerValue": "1"
+                        }
+                      }
                     }
                   }
                 }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a.b"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "a.b"
-            ]
-          },
-          "currentDocument": {
-            "exists": true
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-fp-nosplit.json
+++ b/firestore/v1/testcase/update-paths-fp-nosplit.json
@@ -1,0 +1,53 @@
+{
+  "description": "update-paths: FieldPath elements are not split on dots",
+  "comment": "FieldPath components are not split on dots.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a.b",
+          "f.g"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "{\"n.o\": 7}"
+    ],
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a.b": {
+                "mapValue": {
+                  "fields": {
+                    "f.g": {
+                      "mapValue": {
+                        "fields": {
+                          "n.o": {
+                            "integerValue": "7"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "`a.b`.`f.g`"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-paths-fp-nosplit.json
+++ b/firestore/v1/testcase/update-paths-fp-nosplit.json
@@ -1,53 +1,57 @@
 {
-  "description": "update-paths: FieldPath elements are not split on dots",
-  "comment": "FieldPath components are not split on dots.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a.b",
-          "f.g"
-        ]
-      }
-    ],
-    "jsonValues": [
-      "{\"n.o\": 7}"
-    ],
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a.b": {
-                "mapValue": {
-                  "fields": {
-                    "f.g": {
-                      "mapValue": {
-                        "fields": {
-                          "n.o": {
-                            "integerValue": "7"
+  "tests": [
+    {
+      "description": "update-paths: FieldPath elements are not split on dots",
+      "comment": "FieldPath components are not split on dots.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
+              "a.b",
+              "f.g"
+            ]
+          }
+        ],
+        "jsonValues": [
+          "{\"n.o\": 7}"
+        ],
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a.b": {
+                    "mapValue": {
+                      "fields": {
+                        "f.g": {
+                          "mapValue": {
+                            "fields": {
+                              "n.o": {
+                                "integerValue": "7"
+                              }
+                            }
                           }
                         }
                       }
                     }
                   }
                 }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "`a.b`.`f.g`"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "`a.b`.`f.g`"
-            ]
-          },
-          "currentDocument": {
-            "exists": true
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-nested-transform-and-nested-value.json
+++ b/firestore/v1/testcase/update-paths-nested-transform-and-nested-value.json
@@ -1,0 +1,65 @@
+{
+  "description": "update-paths: Nested transforms should not affect the field mask, even\nwhen there are other values that do. Transforms should only affect the\nDocumentTransform_FieldTransform list.",
+  "comment": "For updates, top-level paths in json-like map inputs\nare split on the dot. That is, an input {\"a.b.c\": 7} results in an update to\nfield c of object b of object a with value 7. In order to specify this behavior,\nthe update must use a fieldmask \"a.b.c\". However, fieldmasks are only used for\nconcrete values - transforms are separately encoded in a\nDocumentTransform_FieldTransform array.\n\nThis test exercises a bug found in python (https://github.com/googleapis/google-cloud-python/issues/7215)\nin which nested transforms ({\"a.c\": \"ServerTimestamp\"}) next to nested values\n({\"a.b\": 7}) incorrectly caused the fieldmask \"a\" to be set, which has the\neffect of wiping out all data in \"a\" other than what was specified in the\njson-like input.\n\nInstead, as this test specifies, transforms should not affect the fieldmask.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a",
+          "b"
+        ]
+      },
+      {
+        "field": [
+          "a",
+          "c"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "7",
+      "\"ServerTimestamp\""
+    ],
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "mapValue": {
+                  "fields": {
+                    "b": {
+                      "integerValue": "7"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a.b"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "a.c",
+                "setToServerValue": "REQUEST_TIME"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-paths-nested-transform-and-nested-value.json
+++ b/firestore/v1/testcase/update-paths-nested-transform-and-nested-value.json
@@ -1,65 +1,69 @@
 {
-  "description": "update-paths: Nested transforms should not affect the field mask, even\nwhen there are other values that do. Transforms should only affect the\nDocumentTransform_FieldTransform list.",
-  "comment": "For updates, top-level paths in json-like map inputs\nare split on the dot. That is, an input {\"a.b.c\": 7} results in an update to\nfield c of object b of object a with value 7. In order to specify this behavior,\nthe update must use a fieldmask \"a.b.c\". However, fieldmasks are only used for\nconcrete values - transforms are separately encoded in a\nDocumentTransform_FieldTransform array.\n\nThis test exercises a bug found in python (https://github.com/googleapis/google-cloud-python/issues/7215)\nin which nested transforms ({\"a.c\": \"ServerTimestamp\"}) next to nested values\n({\"a.b\": 7}) incorrectly caused the fieldmask \"a\" to be set, which has the\neffect of wiping out all data in \"a\" other than what was specified in the\njson-like input.\n\nInstead, as this test specifies, transforms should not affect the fieldmask.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a",
-          "b"
-        ]
-      },
-      {
-        "field": [
-          "a",
-          "c"
-        ]
-      }
-    ],
-    "jsonValues": [
-      "7",
-      "\"ServerTimestamp\""
-    ],
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "mapValue": {
-                  "fields": {
-                    "b": {
-                      "integerValue": "7"
+  "tests": [
+    {
+      "description": "update-paths: Nested transforms should not affect the field mask, even\nwhen there are other values that do. Transforms should only affect the\nDocumentTransform_FieldTransform list.",
+      "comment": "For updates, top-level paths in json-like map inputs\nare split on the dot. That is, an input {\"a.b.c\": 7} results in an update to\nfield c of object b of object a with value 7. In order to specify this behavior,\nthe update must use a fieldmask \"a.b.c\". However, fieldmasks are only used for\nconcrete values - transforms are separately encoded in a\nDocumentTransform_FieldTransform array.\n\nThis test exercises a bug found in python (https://github.com/googleapis/google-cloud-python/issues/7215)\nin which nested transforms ({\"a.c\": \"ServerTimestamp\"}) next to nested values\n({\"a.b\": 7}) incorrectly caused the fieldmask \"a\" to be set, which has the\neffect of wiping out all data in \"a\" other than what was specified in the\njson-like input.\n\nInstead, as this test specifies, transforms should not affect the fieldmask.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
+              "a",
+              "b"
+            ]
+          },
+          {
+            "field": [
+              "a",
+              "c"
+            ]
+          }
+        ],
+        "jsonValues": [
+          "7",
+          "\"ServerTimestamp\""
+        ],
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "mapValue": {
+                      "fields": {
+                        "b": {
+                          "integerValue": "7"
+                        }
+                      }
                     }
                   }
                 }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a.b"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "a.c",
+                    "setToServerValue": "REQUEST_TIME"
+                  }
+                ]
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "a.b"
-            ]
-          },
-          "currentDocument": {
-            "exists": true
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "a.c",
-                "setToServerValue": "REQUEST_TIME"
-              }
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-no-paths.json
+++ b/firestore/v1/testcase/update-paths-no-paths.json
@@ -1,0 +1,8 @@
+{
+  "description": "update-paths: no paths",
+  "comment": "It is a client-side error to call Update with empty data.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-paths-no-paths.json
+++ b/firestore/v1/testcase/update-paths-no-paths.json
@@ -1,8 +1,12 @@
 {
-  "description": "update-paths: no paths",
-  "comment": "It is a client-side error to call Update with empty data.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "update-paths: no paths",
+      "comment": "It is a client-side error to call Update with empty data.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-prefix-1.json
+++ b/firestore/v1/testcase/update-paths-prefix-1.json
@@ -1,0 +1,25 @@
+{
+  "description": "update-paths: prefix #1",
+  "comment": "In the input data, one field cannot be a prefix of another.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a",
+          "b"
+        ]
+      },
+      {
+        "field": [
+          "a"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "1",
+      "2"
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-paths-prefix-1.json
+++ b/firestore/v1/testcase/update-paths-prefix-1.json
@@ -1,25 +1,29 @@
 {
-  "description": "update-paths: prefix #1",
-  "comment": "In the input data, one field cannot be a prefix of another.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a",
-          "b"
-        ]
-      },
-      {
-        "field": [
-          "a"
-        ]
+  "tests": [
+    {
+      "description": "update-paths: prefix #1",
+      "comment": "In the input data, one field cannot be a prefix of another.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
+              "a",
+              "b"
+            ]
+          },
+          {
+            "field": [
+              "a"
+            ]
+          }
+        ],
+        "jsonValues": [
+          "1",
+          "2"
+        ],
+        "isError": true
       }
-    ],
-    "jsonValues": [
-      "1",
-      "2"
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-prefix-2.json
+++ b/firestore/v1/testcase/update-paths-prefix-2.json
@@ -1,0 +1,25 @@
+{
+  "description": "update-paths: prefix #2",
+  "comment": "In the input data, one field cannot be a prefix of another.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      },
+      {
+        "field": [
+          "a",
+          "b"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "1",
+      "2"
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-paths-prefix-2.json
+++ b/firestore/v1/testcase/update-paths-prefix-2.json
@@ -1,25 +1,29 @@
 {
-  "description": "update-paths: prefix #2",
-  "comment": "In the input data, one field cannot be a prefix of another.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
-      },
-      {
-        "field": [
-          "a",
-          "b"
-        ]
+  "tests": [
+    {
+      "description": "update-paths: prefix #2",
+      "comment": "In the input data, one field cannot be a prefix of another.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
+              "a"
+            ]
+          },
+          {
+            "field": [
+              "a",
+              "b"
+            ]
+          }
+        ],
+        "jsonValues": [
+          "1",
+          "2"
+        ],
+        "isError": true
       }
-    ],
-    "jsonValues": [
-      "1",
-      "2"
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-prefix-3.json
+++ b/firestore/v1/testcase/update-paths-prefix-3.json
@@ -1,0 +1,25 @@
+{
+  "description": "update-paths: prefix #3",
+  "comment": "In the input data, one field cannot be a prefix of another, even if the values could in principle be combined.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      },
+      {
+        "field": [
+          "a",
+          "d"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "{\"b\": 1}",
+      "2"
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-paths-prefix-3.json
+++ b/firestore/v1/testcase/update-paths-prefix-3.json
@@ -1,25 +1,29 @@
 {
-  "description": "update-paths: prefix #3",
-  "comment": "In the input data, one field cannot be a prefix of another, even if the values could in principle be combined.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
-      },
-      {
-        "field": [
-          "a",
-          "d"
-        ]
+  "tests": [
+    {
+      "description": "update-paths: prefix #3",
+      "comment": "In the input data, one field cannot be a prefix of another, even if the values could in principle be combined.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
+              "a"
+            ]
+          },
+          {
+            "field": [
+              "a",
+              "d"
+            ]
+          }
+        ],
+        "jsonValues": [
+          "{\"b\": 1}",
+          "2"
+        ],
+        "isError": true
       }
-    ],
-    "jsonValues": [
-      "{\"b\": 1}",
-      "2"
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-special-chars.json
+++ b/firestore/v1/testcase/update-paths-special-chars.json
@@ -1,0 +1,58 @@
+{
+  "description": "update-paths: special characters",
+  "comment": "FieldPaths can contain special characters.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "*",
+          "~"
+        ]
+      },
+      {
+        "field": [
+          "*",
+          "`"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "1",
+      "2"
+    ],
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "*": {
+                "mapValue": {
+                  "fields": {
+                    "`": {
+                      "integerValue": "2"
+                    },
+                    "~": {
+                      "integerValue": "1"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "`*`.`\\``",
+              "`*`.`~`"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-paths-special-chars.json
+++ b/firestore/v1/testcase/update-paths-special-chars.json
@@ -1,58 +1,62 @@
 {
-  "description": "update-paths: special characters",
-  "comment": "FieldPaths can contain special characters.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "*",
-          "~"
-        ]
-      },
-      {
-        "field": [
-          "*",
-          "`"
-        ]
-      }
-    ],
-    "jsonValues": [
-      "1",
-      "2"
-    ],
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "*": {
-                "mapValue": {
-                  "fields": {
-                    "`": {
-                      "integerValue": "2"
-                    },
-                    "~": {
-                      "integerValue": "1"
+  "tests": [
+    {
+      "description": "update-paths: special characters",
+      "comment": "FieldPaths can contain special characters.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
+              "*",
+              "~"
+            ]
+          },
+          {
+            "field": [
+              "*",
+              "`"
+            ]
+          }
+        ],
+        "jsonValues": [
+          "1",
+          "2"
+        ],
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "*": {
+                    "mapValue": {
+                      "fields": {
+                        "`": {
+                          "integerValue": "2"
+                        },
+                        "~": {
+                          "integerValue": "1"
+                        }
+                      }
                     }
                   }
                 }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "`*`.`\\``",
+                  "`*`.`~`"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "`*`.`\\``",
-              "`*`.`~`"
-            ]
-          },
-          "currentDocument": {
-            "exists": true
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-st-alone.json
+++ b/firestore/v1/testcase/update-paths-st-alone.json
@@ -1,0 +1,36 @@
+{
+  "description": "update-paths: ServerTimestamp alone",
+  "comment": "If the only values in the input are ServerTimestamps, then no\nupdate operation should be produced.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "\"ServerTimestamp\""
+    ],
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "a",
+                "setToServerValue": "REQUEST_TIME"
+              }
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-paths-st-alone.json
+++ b/firestore/v1/testcase/update-paths-st-alone.json
@@ -1,36 +1,40 @@
 {
-  "description": "update-paths: ServerTimestamp alone",
-  "comment": "If the only values in the input are ServerTimestamps, then no\nupdate operation should be produced.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
-      }
-    ],
-    "jsonValues": [
-      "\"ServerTimestamp\""
-    ],
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "a",
-                "setToServerValue": "REQUEST_TIME"
-              }
+  "tests": [
+    {
+      "description": "update-paths: ServerTimestamp alone",
+      "comment": "If the only values in the input are ServerTimestamps, then no\nupdate operation should be produced.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
+              "a"
             ]
-          },
-          "currentDocument": {
-            "exists": true
           }
+        ],
+        "jsonValues": [
+          "\"ServerTimestamp\""
+        ],
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "a",
+                    "setToServerValue": "REQUEST_TIME"
+                  }
+                ]
+              },
+              "currentDocument": {
+                "exists": true
+              }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-st-multi.json
+++ b/firestore/v1/testcase/update-paths-st-multi.json
@@ -1,0 +1,68 @@
+{
+  "description": "update-paths: multiple ServerTimestamp fields",
+  "comment": "A document can have more than one ServerTimestamp field.\nSince all the ServerTimestamp fields are removed, the only field in the update is \"a\".",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      },
+      {
+        "field": [
+          "b"
+        ]
+      },
+      {
+        "field": [
+          "c"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "1",
+      "\"ServerTimestamp\"",
+      "{\"d\": \"ServerTimestamp\"}"
+    ],
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a",
+              "c"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b",
+                "setToServerValue": "REQUEST_TIME"
+              },
+              {
+                "fieldPath": "c.d",
+                "setToServerValue": "REQUEST_TIME"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-paths-st-multi.json
+++ b/firestore/v1/testcase/update-paths-st-multi.json
@@ -1,68 +1,72 @@
 {
-  "description": "update-paths: multiple ServerTimestamp fields",
-  "comment": "A document can have more than one ServerTimestamp field.\nSince all the ServerTimestamp fields are removed, the only field in the update is \"a\".",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
-      },
-      {
-        "field": [
-          "b"
-        ]
-      },
-      {
-        "field": [
-          "c"
-        ]
-      }
-    ],
-    "jsonValues": [
-      "1",
-      "\"ServerTimestamp\"",
-      "{\"d\": \"ServerTimestamp\"}"
-    ],
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            }
+  "tests": [
+    {
+      "description": "update-paths: multiple ServerTimestamp fields",
+      "comment": "A document can have more than one ServerTimestamp field.\nSince all the ServerTimestamp fields are removed, the only field in the update is \"a\".",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
+              "a"
+            ]
           },
-          "updateMask": {
-            "fieldPaths": [
-              "a",
+          {
+            "field": [
+              "b"
+            ]
+          },
+          {
+            "field": [
               "c"
             ]
-          },
-          "currentDocument": {
-            "exists": true
           }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b",
-                "setToServerValue": "REQUEST_TIME"
+        ],
+        "jsonValues": [
+          "1",
+          "\"ServerTimestamp\"",
+          "{\"d\": \"ServerTimestamp\"}"
+        ],
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
               },
-              {
-                "fieldPath": "c.d",
-                "setToServerValue": "REQUEST_TIME"
+              "updateMask": {
+                "fieldPaths": [
+                  "a",
+                  "c"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
               }
-            ]
-          }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b",
+                    "setToServerValue": "REQUEST_TIME"
+                  },
+                  {
+                    "fieldPath": "c.d",
+                    "setToServerValue": "REQUEST_TIME"
+                  }
+                ]
+              }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-st-nested.json
+++ b/firestore/v1/testcase/update-paths-st-nested.json
@@ -1,0 +1,58 @@
+{
+  "description": "update-paths: nested ServerTimestamp field",
+  "comment": "A ServerTimestamp value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      },
+      {
+        "field": [
+          "b"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "1",
+      "{\"c\": \"ServerTimestamp\"}"
+    ],
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a",
+              "b"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b.c",
+                "setToServerValue": "REQUEST_TIME"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-paths-st-nested.json
+++ b/firestore/v1/testcase/update-paths-st-nested.json
@@ -1,58 +1,62 @@
 {
-  "description": "update-paths: nested ServerTimestamp field",
-  "comment": "A ServerTimestamp value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
-      },
-      {
-        "field": [
-          "b"
-        ]
-      }
-    ],
-    "jsonValues": [
-      "1",
-      "{\"c\": \"ServerTimestamp\"}"
-    ],
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            }
+  "tests": [
+    {
+      "description": "update-paths: nested ServerTimestamp field",
+      "comment": "A ServerTimestamp value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
+              "a"
+            ]
           },
-          "updateMask": {
-            "fieldPaths": [
-              "a",
+          {
+            "field": [
               "b"
             ]
-          },
-          "currentDocument": {
-            "exists": true
           }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b.c",
-                "setToServerValue": "REQUEST_TIME"
+        ],
+        "jsonValues": [
+          "1",
+          "{\"c\": \"ServerTimestamp\"}"
+        ],
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a",
+                  "b"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
               }
-            ]
-          }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b.c",
+                    "setToServerValue": "REQUEST_TIME"
+                  }
+                ]
+              }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-st-noarray-nested.json
+++ b/firestore/v1/testcase/update-paths-st-noarray-nested.json
@@ -1,0 +1,18 @@
+{
+  "description": "update-paths: ServerTimestamp cannot be anywhere inside an array value",
+  "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ServerTimestamp sentinel. Firestore transforms don't support array indexing.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "[1, {\"b\": \"ServerTimestamp\"}]"
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-paths-st-noarray-nested.json
+++ b/firestore/v1/testcase/update-paths-st-noarray-nested.json
@@ -1,18 +1,22 @@
 {
-  "description": "update-paths: ServerTimestamp cannot be anywhere inside an array value",
-  "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ServerTimestamp sentinel. Firestore transforms don't support array indexing.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
+  "tests": [
+    {
+      "description": "update-paths: ServerTimestamp cannot be anywhere inside an array value",
+      "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ServerTimestamp sentinel. Firestore transforms don't support array indexing.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
+              "a"
+            ]
+          }
+        ],
+        "jsonValues": [
+          "[1, {\"b\": \"ServerTimestamp\"}]"
+        ],
+        "isError": true
       }
-    ],
-    "jsonValues": [
-      "[1, {\"b\": \"ServerTimestamp\"}]"
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-st-noarray.json
+++ b/firestore/v1/testcase/update-paths-st-noarray.json
@@ -1,0 +1,18 @@
+{
+  "description": "update-paths: ServerTimestamp cannot be in an array value",
+  "comment": "The ServerTimestamp sentinel must be the value of a field. Firestore\ntransforms don't support array indexing.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "[1, 2, \"ServerTimestamp\"]"
+    ],
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-paths-st-noarray.json
+++ b/firestore/v1/testcase/update-paths-st-noarray.json
@@ -1,18 +1,22 @@
 {
-  "description": "update-paths: ServerTimestamp cannot be in an array value",
-  "comment": "The ServerTimestamp sentinel must be the value of a field. Firestore\ntransforms don't support array indexing.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
+  "tests": [
+    {
+      "description": "update-paths: ServerTimestamp cannot be in an array value",
+      "comment": "The ServerTimestamp sentinel must be the value of a field. Firestore\ntransforms don't support array indexing.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
+              "a"
+            ]
+          }
+        ],
+        "jsonValues": [
+          "[1, 2, \"ServerTimestamp\"]"
+        ],
+        "isError": true
       }
-    ],
-    "jsonValues": [
-      "[1, 2, \"ServerTimestamp\"]"
-    ],
-    "isError": true
-  }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-st-with-empty-map.json
+++ b/firestore/v1/testcase/update-paths-st-with-empty-map.json
@@ -1,0 +1,59 @@
+{
+  "description": "update-paths: ServerTimestamp beside an empty map",
+  "comment": "When a ServerTimestamp and a map both reside inside a map, the\nServerTimestamp should be stripped out but the empty map should remain.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "{\"b\": {}, \"c\": \"ServerTimestamp\"}"
+    ],
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "mapValue": {
+                  "fields": {
+                    "b": {
+                      "mapValue": {
+                        "fields": {}
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "a.c",
+                "setToServerValue": "REQUEST_TIME"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-paths-st-with-empty-map.json
+++ b/firestore/v1/testcase/update-paths-st-with-empty-map.json
@@ -1,59 +1,63 @@
 {
-  "description": "update-paths: ServerTimestamp beside an empty map",
-  "comment": "When a ServerTimestamp and a map both reside inside a map, the\nServerTimestamp should be stripped out but the empty map should remain.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
-      }
-    ],
-    "jsonValues": [
-      "{\"b\": {}, \"c\": \"ServerTimestamp\"}"
-    ],
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "mapValue": {
-                  "fields": {
-                    "b": {
-                      "mapValue": {
-                        "fields": {}
+  "tests": [
+    {
+      "description": "update-paths: ServerTimestamp beside an empty map",
+      "comment": "When a ServerTimestamp and a map both reside inside a map, the\nServerTimestamp should be stripped out but the empty map should remain.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
+              "a"
+            ]
+          }
+        ],
+        "jsonValues": [
+          "{\"b\": {}, \"c\": \"ServerTimestamp\"}"
+        ],
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "mapValue": {
+                      "fields": {
+                        "b": {
+                          "mapValue": {
+                            "fields": {}
+                          }
+                        }
                       }
                     }
                   }
                 }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "a.c",
+                    "setToServerValue": "REQUEST_TIME"
+                  }
+                ]
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "a"
-            ]
-          },
-          "currentDocument": {
-            "exists": true
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "a.c",
-                "setToServerValue": "REQUEST_TIME"
-              }
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-st.json
+++ b/firestore/v1/testcase/update-paths-st.json
@@ -1,0 +1,57 @@
+{
+  "description": "update-paths: ServerTimestamp with data",
+  "comment": "A key with the special ServerTimestamp sentinel is removed from\nthe data in the update operation. Instead it appears in a separate Transform operation.\nNote that in these tests, the string \"ServerTimestamp\" should be replaced with the\nspecial ServerTimestamp value.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      },
+      {
+        "field": [
+          "b"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "1",
+      "\"ServerTimestamp\""
+    ],
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b",
+                "setToServerValue": "REQUEST_TIME"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-paths-st.json
+++ b/firestore/v1/testcase/update-paths-st.json
@@ -1,57 +1,61 @@
 {
-  "description": "update-paths: ServerTimestamp with data",
-  "comment": "A key with the special ServerTimestamp sentinel is removed from\nthe data in the update operation. Instead it appears in a separate Transform operation.\nNote that in these tests, the string \"ServerTimestamp\" should be replaced with the\nspecial ServerTimestamp value.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
-      },
-      {
-        "field": [
-          "b"
-        ]
-      }
-    ],
-    "jsonValues": [
-      "1",
-      "\"ServerTimestamp\""
-    ],
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            }
-          },
-          "updateMask": {
-            "fieldPaths": [
+  "tests": [
+    {
+      "description": "update-paths: ServerTimestamp with data",
+      "comment": "A key with the special ServerTimestamp sentinel is removed from\nthe data in the update operation. Instead it appears in a separate Transform operation.\nNote that in these tests, the string \"ServerTimestamp\" should be replaced with the\nspecial ServerTimestamp value.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "fieldPaths": [
+          {
+            "field": [
               "a"
             ]
           },
-          "currentDocument": {
-            "exists": true
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b",
-                "setToServerValue": "REQUEST_TIME"
-              }
+          {
+            "field": [
+              "b"
             ]
           }
+        ],
+        "jsonValues": [
+          "1",
+          "\"ServerTimestamp\""
+        ],
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b",
+                    "setToServerValue": "REQUEST_TIME"
+                  }
+                ]
+              }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-paths-uptime.json
+++ b/firestore/v1/testcase/update-paths-uptime.json
@@ -1,0 +1,43 @@
+{
+  "description": "update-paths: last-update-time precondition",
+  "comment": "The Update call supports a last-update-time precondition.",
+  "updatePaths": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "precondition": {
+      "updateTime": "1970-01-01T00:00:42Z"
+    },
+    "fieldPaths": [
+      {
+        "field": [
+          "a"
+        ]
+      }
+    ],
+    "jsonValues": [
+      "1"
+    ],
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a"
+            ]
+          },
+          "currentDocument": {
+            "updateTime": "1970-01-01T00:00:42Z"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-paths-uptime.json
+++ b/firestore/v1/testcase/update-paths-uptime.json
@@ -1,43 +1,47 @@
 {
-  "description": "update-paths: last-update-time precondition",
-  "comment": "The Update call supports a last-update-time precondition.",
-  "updatePaths": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "precondition": {
-      "updateTime": "1970-01-01T00:00:42Z"
-    },
-    "fieldPaths": [
-      {
-        "field": [
-          "a"
-        ]
-      }
-    ],
-    "jsonValues": [
-      "1"
-    ],
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
-              }
-            }
-          },
-          "updateMask": {
-            "fieldPaths": [
+  "tests": [
+    {
+      "description": "update-paths: last-update-time precondition",
+      "comment": "The Update call supports a last-update-time precondition.",
+      "updatePaths": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "precondition": {
+          "updateTime": "1970-01-01T00:00:42Z"
+        },
+        "fieldPaths": [
+          {
+            "field": [
               "a"
             ]
-          },
-          "currentDocument": {
-            "updateTime": "1970-01-01T00:00:42Z"
           }
+        ],
+        "jsonValues": [
+          "1"
+        ],
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a"
+                ]
+              },
+              "currentDocument": {
+                "updateTime": "1970-01-01T00:00:42Z"
+              }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-prefix-1.json
+++ b/firestore/v1/testcase/update-prefix-1.json
@@ -1,0 +1,9 @@
+{
+  "description": "update: prefix #1",
+  "comment": "In the input data, one field cannot be a prefix of another.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a.b\": 1, \"a\": 2}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-prefix-1.json
+++ b/firestore/v1/testcase/update-prefix-1.json
@@ -1,9 +1,13 @@
 {
-  "description": "update: prefix #1",
-  "comment": "In the input data, one field cannot be a prefix of another.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a.b\": 1, \"a\": 2}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "update: prefix #1",
+      "comment": "In the input data, one field cannot be a prefix of another.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a.b\": 1, \"a\": 2}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-prefix-2.json
+++ b/firestore/v1/testcase/update-prefix-2.json
@@ -1,0 +1,9 @@
+{
+  "description": "update: prefix #2",
+  "comment": "In the input data, one field cannot be a prefix of another.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"a.b\": 2}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-prefix-2.json
+++ b/firestore/v1/testcase/update-prefix-2.json
@@ -1,9 +1,13 @@
 {
-  "description": "update: prefix #2",
-  "comment": "In the input data, one field cannot be a prefix of another.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"a.b\": 2}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "update: prefix #2",
+      "comment": "In the input data, one field cannot be a prefix of another.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"a.b\": 2}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-prefix-3.json
+++ b/firestore/v1/testcase/update-prefix-3.json
@@ -1,0 +1,9 @@
+{
+  "description": "update: prefix #3",
+  "comment": "In the input data, one field cannot be a prefix of another, even if the values could in principle be combined.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": {\"b\": 1}, \"a.d\": 2}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-prefix-3.json
+++ b/firestore/v1/testcase/update-prefix-3.json
@@ -1,9 +1,13 @@
 {
-  "description": "update: prefix #3",
-  "comment": "In the input data, one field cannot be a prefix of another, even if the values could in principle be combined.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": {\"b\": 1}, \"a.d\": 2}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "update: prefix #3",
+      "comment": "In the input data, one field cannot be a prefix of another, even if the values could in principle be combined.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": {\"b\": 1}, \"a.d\": 2}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-quoting.json
+++ b/firestore/v1/testcase/update-quoting.json
@@ -1,0 +1,43 @@
+{
+  "description": "update: non-letter starting chars are quoted, except underscore",
+  "comment": "In a field path, any component beginning with a non-letter or underscore is quoted.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"_0.1.+2\": 1}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "_0": {
+                "mapValue": {
+                  "fields": {
+                    "1": {
+                      "mapValue": {
+                        "fields": {
+                          "+2": {
+                            "integerValue": "1"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "_0.`1`.`+2`"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-quoting.json
+++ b/firestore/v1/testcase/update-quoting.json
@@ -1,43 +1,47 @@
 {
-  "description": "update: non-letter starting chars are quoted, except underscore",
-  "comment": "In a field path, any component beginning with a non-letter or underscore is quoted.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"_0.1.+2\": 1}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "_0": {
-                "mapValue": {
-                  "fields": {
-                    "1": {
-                      "mapValue": {
-                        "fields": {
-                          "+2": {
-                            "integerValue": "1"
+  "tests": [
+    {
+      "description": "update: non-letter starting chars are quoted, except underscore",
+      "comment": "In a field path, any component beginning with a non-letter or underscore is quoted.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"_0.1.+2\": 1}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "_0": {
+                    "mapValue": {
+                      "fields": {
+                        "1": {
+                          "mapValue": {
+                            "fields": {
+                              "+2": {
+                                "integerValue": "1"
+                              }
+                            }
                           }
                         }
                       }
                     }
                   }
                 }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "_0.`1`.`+2`"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "_0.`1`.`+2`"
-            ]
-          },
-          "currentDocument": {
-            "exists": true
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-split-top-level.json
+++ b/firestore/v1/testcase/update-split-top-level.json
@@ -1,0 +1,43 @@
+{
+  "description": "update: Split on dots for top-level keys only",
+  "comment": "The Update method splits only top-level keys at dots. Keys at\nother levels are taken literally.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"h.g\": {\"j.k\": 6}}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "h": {
+                "mapValue": {
+                  "fields": {
+                    "g": {
+                      "mapValue": {
+                        "fields": {
+                          "j.k": {
+                            "integerValue": "6"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "h.g"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-split-top-level.json
+++ b/firestore/v1/testcase/update-split-top-level.json
@@ -1,43 +1,47 @@
 {
-  "description": "update: Split on dots for top-level keys only",
-  "comment": "The Update method splits only top-level keys at dots. Keys at\nother levels are taken literally.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"h.g\": {\"j.k\": 6}}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "h": {
-                "mapValue": {
-                  "fields": {
-                    "g": {
-                      "mapValue": {
-                        "fields": {
-                          "j.k": {
-                            "integerValue": "6"
+  "tests": [
+    {
+      "description": "update: Split on dots for top-level keys only",
+      "comment": "The Update method splits only top-level keys at dots. Keys at\nother levels are taken literally.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"h.g\": {\"j.k\": 6}}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "h": {
+                    "mapValue": {
+                      "fields": {
+                        "g": {
+                          "mapValue": {
+                            "fields": {
+                              "j.k": {
+                                "integerValue": "6"
+                              }
+                            }
                           }
                         }
                       }
                     }
                   }
                 }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "h.g"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "h.g"
-            ]
-          },
-          "currentDocument": {
-            "exists": true
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-split.json
+++ b/firestore/v1/testcase/update-split.json
@@ -1,0 +1,43 @@
+{
+  "description": "update: split on dots",
+  "comment": "The Update method splits top-level keys at dots.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a.b.c\": 1}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "mapValue": {
+                  "fields": {
+                    "b": {
+                      "mapValue": {
+                        "fields": {
+                          "c": {
+                            "integerValue": "1"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a.b.c"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-split.json
+++ b/firestore/v1/testcase/update-split.json
@@ -1,43 +1,47 @@
 {
-  "description": "update: split on dots",
-  "comment": "The Update method splits top-level keys at dots.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a.b.c\": 1}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "mapValue": {
-                  "fields": {
-                    "b": {
-                      "mapValue": {
-                        "fields": {
-                          "c": {
-                            "integerValue": "1"
+  "tests": [
+    {
+      "description": "update: split on dots",
+      "comment": "The Update method splits top-level keys at dots.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a.b.c\": 1}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "mapValue": {
+                      "fields": {
+                        "b": {
+                          "mapValue": {
+                            "fields": {
+                              "c": {
+                                "integerValue": "1"
+                              }
+                            }
                           }
                         }
                       }
                     }
                   }
                 }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a.b.c"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "a.b.c"
-            ]
-          },
-          "currentDocument": {
-            "exists": true
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-st-alone.json
+++ b/firestore/v1/testcase/update-st-alone.json
@@ -1,0 +1,27 @@
+{
+  "description": "update: ServerTimestamp alone",
+  "comment": "If the only values in the input are ServerTimestamps, then no\nupdate operation should be produced.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": \"ServerTimestamp\"}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "a",
+                "setToServerValue": "REQUEST_TIME"
+              }
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-st-alone.json
+++ b/firestore/v1/testcase/update-st-alone.json
@@ -1,27 +1,31 @@
 {
-  "description": "update: ServerTimestamp alone",
-  "comment": "If the only values in the input are ServerTimestamps, then no\nupdate operation should be produced.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": \"ServerTimestamp\"}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "a",
-                "setToServerValue": "REQUEST_TIME"
+  "tests": [
+    {
+      "description": "update: ServerTimestamp alone",
+      "comment": "If the only values in the input are ServerTimestamps, then no\nupdate operation should be produced.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": \"ServerTimestamp\"}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "a",
+                    "setToServerValue": "REQUEST_TIME"
+                  }
+                ]
+              },
+              "currentDocument": {
+                "exists": true
               }
-            ]
-          },
-          "currentDocument": {
-            "exists": true
-          }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-st-dot.json
+++ b/firestore/v1/testcase/update-st-dot.json
@@ -1,0 +1,27 @@
+{
+  "description": "update: ServerTimestamp with dotted field",
+  "comment": "Like other uses of ServerTimestamp, the data is pruned and the\nfield does not appear in the update mask, because it is in the transform. In this case\nAn update operation is produced just to hold the precondition.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a.b.c\": \"ServerTimestamp\"}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "a.b.c",
+                "setToServerValue": "REQUEST_TIME"
+              }
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-st-dot.json
+++ b/firestore/v1/testcase/update-st-dot.json
@@ -1,27 +1,31 @@
 {
-  "description": "update: ServerTimestamp with dotted field",
-  "comment": "Like other uses of ServerTimestamp, the data is pruned and the\nfield does not appear in the update mask, because it is in the transform. In this case\nAn update operation is produced just to hold the precondition.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a.b.c\": \"ServerTimestamp\"}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "a.b.c",
-                "setToServerValue": "REQUEST_TIME"
+  "tests": [
+    {
+      "description": "update: ServerTimestamp with dotted field",
+      "comment": "Like other uses of ServerTimestamp, the data is pruned and the\nfield does not appear in the update mask, because it is in the transform. In this case\nAn update operation is produced just to hold the precondition.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a.b.c\": \"ServerTimestamp\"}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "a.b.c",
+                    "setToServerValue": "REQUEST_TIME"
+                  }
+                ]
+              },
+              "currentDocument": {
+                "exists": true
               }
-            ]
-          },
-          "currentDocument": {
-            "exists": true
-          }
+            }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-st-multi.json
+++ b/firestore/v1/testcase/update-st-multi.json
@@ -1,0 +1,47 @@
+{
+  "description": "update: multiple ServerTimestamp fields",
+  "comment": "A document can have more than one ServerTimestamp field.\nSince all the ServerTimestamp fields are removed, the only field in the update is \"a\".",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\", \"c\": {\"d\": \"ServerTimestamp\"}}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a",
+              "c"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b",
+                "setToServerValue": "REQUEST_TIME"
+              },
+              {
+                "fieldPath": "c.d",
+                "setToServerValue": "REQUEST_TIME"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-st-multi.json
+++ b/firestore/v1/testcase/update-st-multi.json
@@ -1,47 +1,51 @@
 {
-  "description": "update: multiple ServerTimestamp fields",
-  "comment": "A document can have more than one ServerTimestamp field.\nSince all the ServerTimestamp fields are removed, the only field in the update is \"a\".",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\", \"c\": {\"d\": \"ServerTimestamp\"}}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
+  "tests": [
+    {
+      "description": "update: multiple ServerTimestamp fields",
+      "comment": "A document can have more than one ServerTimestamp field.\nSince all the ServerTimestamp fields are removed, the only field in the update is \"a\".",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\", \"c\": {\"d\": \"ServerTimestamp\"}}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a",
+                  "c"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b",
+                    "setToServerValue": "REQUEST_TIME"
+                  },
+                  {
+                    "fieldPath": "c.d",
+                    "setToServerValue": "REQUEST_TIME"
+                  }
+                ]
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "a",
-              "c"
-            ]
-          },
-          "currentDocument": {
-            "exists": true
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b",
-                "setToServerValue": "REQUEST_TIME"
-              },
-              {
-                "fieldPath": "c.d",
-                "setToServerValue": "REQUEST_TIME"
-              }
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-st-nested.json
+++ b/firestore/v1/testcase/update-st-nested.json
@@ -1,0 +1,43 @@
+{
+  "description": "update: nested ServerTimestamp field",
+  "comment": "A ServerTimestamp value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b\": {\"c\": \"ServerTimestamp\"}}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a",
+              "b"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b.c",
+                "setToServerValue": "REQUEST_TIME"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-st-nested.json
+++ b/firestore/v1/testcase/update-st-nested.json
@@ -1,43 +1,47 @@
 {
-  "description": "update: nested ServerTimestamp field",
-  "comment": "A ServerTimestamp value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b\": {\"c\": \"ServerTimestamp\"}}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
+  "tests": [
+    {
+      "description": "update: nested ServerTimestamp field",
+      "comment": "A ServerTimestamp value can occur at any depth. In this case,\nthe transform applies to the field path \"b.c\". Since \"c\" is removed from the update,\n\"b\" becomes empty, so it is also removed from the update.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b\": {\"c\": \"ServerTimestamp\"}}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a",
+                  "b"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b.c",
+                    "setToServerValue": "REQUEST_TIME"
+                  }
+                ]
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "a",
-              "b"
-            ]
-          },
-          "currentDocument": {
-            "exists": true
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b.c",
-                "setToServerValue": "REQUEST_TIME"
-              }
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-st-noarray-nested.json
+++ b/firestore/v1/testcase/update-st-noarray-nested.json
@@ -1,0 +1,9 @@
+{
+  "description": "update: ServerTimestamp cannot be anywhere inside an array value",
+  "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ServerTimestamp sentinel. Firestore transforms don't support array indexing.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [1, {\"b\": \"ServerTimestamp\"}]}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-st-noarray-nested.json
+++ b/firestore/v1/testcase/update-st-noarray-nested.json
@@ -1,9 +1,13 @@
 {
-  "description": "update: ServerTimestamp cannot be anywhere inside an array value",
-  "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ServerTimestamp sentinel. Firestore transforms don't support array indexing.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [1, {\"b\": \"ServerTimestamp\"}]}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "update: ServerTimestamp cannot be anywhere inside an array value",
+      "comment": "There cannot be an array value anywhere on the path from the document\nroot to the ServerTimestamp sentinel. Firestore transforms don't support array indexing.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [1, {\"b\": \"ServerTimestamp\"}]}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-st-noarray.json
+++ b/firestore/v1/testcase/update-st-noarray.json
@@ -1,0 +1,9 @@
+{
+  "description": "update: ServerTimestamp cannot be in an array value",
+  "comment": "The ServerTimestamp sentinel must be the value of a field. Firestore\ntransforms don't support array indexing.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": [1, 2, \"ServerTimestamp\"]}",
+    "isError": true
+  }
+}

--- a/firestore/v1/testcase/update-st-noarray.json
+++ b/firestore/v1/testcase/update-st-noarray.json
@@ -1,9 +1,13 @@
 {
-  "description": "update: ServerTimestamp cannot be in an array value",
-  "comment": "The ServerTimestamp sentinel must be the value of a field. Firestore\ntransforms don't support array indexing.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": [1, 2, \"ServerTimestamp\"]}",
-    "isError": true
-  }
+  "tests": [
+    {
+      "description": "update: ServerTimestamp cannot be in an array value",
+      "comment": "The ServerTimestamp sentinel must be the value of a field. Firestore\ntransforms don't support array indexing.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": [1, 2, \"ServerTimestamp\"]}",
+        "isError": true
+      }
+    }
+  ]
 }

--- a/firestore/v1/testcase/update-st-with-empty-map.json
+++ b/firestore/v1/testcase/update-st-with-empty-map.json
@@ -1,0 +1,50 @@
+{
+  "description": "update: ServerTimestamp beside an empty map",
+  "comment": "When a ServerTimestamp and a map both reside inside a map, the\nServerTimestamp should be stripped out but the empty map should remain.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": {\"b\": {}, \"c\": \"ServerTimestamp\"}}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "mapValue": {
+                  "fields": {
+                    "b": {
+                      "mapValue": {
+                        "fields": {}
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "a.c",
+                "setToServerValue": "REQUEST_TIME"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-st-with-empty-map.json
+++ b/firestore/v1/testcase/update-st-with-empty-map.json
@@ -1,50 +1,54 @@
 {
-  "description": "update: ServerTimestamp beside an empty map",
-  "comment": "When a ServerTimestamp and a map both reside inside a map, the\nServerTimestamp should be stripped out but the empty map should remain.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": {\"b\": {}, \"c\": \"ServerTimestamp\"}}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "mapValue": {
-                  "fields": {
-                    "b": {
-                      "mapValue": {
-                        "fields": {}
+  "tests": [
+    {
+      "description": "update: ServerTimestamp beside an empty map",
+      "comment": "When a ServerTimestamp and a map both reside inside a map, the\nServerTimestamp should be stripped out but the empty map should remain.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": {\"b\": {}, \"c\": \"ServerTimestamp\"}}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "mapValue": {
+                      "fields": {
+                        "b": {
+                          "mapValue": {
+                            "fields": {}
+                          }
+                        }
                       }
                     }
                   }
                 }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "a.c",
+                    "setToServerValue": "REQUEST_TIME"
+                  }
+                ]
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "a"
-            ]
-          },
-          "currentDocument": {
-            "exists": true
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "a.c",
-                "setToServerValue": "REQUEST_TIME"
-              }
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-st.json
+++ b/firestore/v1/testcase/update-st.json
@@ -1,0 +1,42 @@
+{
+  "description": "update: ServerTimestamp with data",
+  "comment": "A key with the special ServerTimestamp sentinel is removed from\nthe data in the update operation. Instead it appears in a separate Transform operation.\nNote that in these tests, the string \"ServerTimestamp\" should be replaced with the\nspecial ServerTimestamp value.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\"}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a"
+            ]
+          },
+          "currentDocument": {
+            "exists": true
+          }
+        },
+        {
+          "transform": {
+            "document": "projects/projectID/databases/(default)/documents/C/d",
+            "fieldTransforms": [
+              {
+                "fieldPath": "b",
+                "setToServerValue": "REQUEST_TIME"
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-st.json
+++ b/firestore/v1/testcase/update-st.json
@@ -1,42 +1,46 @@
 {
-  "description": "update: ServerTimestamp with data",
-  "comment": "A key with the special ServerTimestamp sentinel is removed from\nthe data in the update operation. Instead it appears in a separate Transform operation.\nNote that in these tests, the string \"ServerTimestamp\" should be replaced with the\nspecial ServerTimestamp value.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\"}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
+  "tests": [
+    {
+      "description": "update: ServerTimestamp with data",
+      "comment": "A key with the special ServerTimestamp sentinel is removed from\nthe data in the update operation. Instead it appears in a separate Transform operation.\nNote that in these tests, the string \"ServerTimestamp\" should be replaced with the\nspecial ServerTimestamp value.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "jsonData": "{\"a\": 1, \"b\": \"ServerTimestamp\"}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a"
+                ]
+              },
+              "currentDocument": {
+                "exists": true
+              }
+            },
+            {
+              "transform": {
+                "document": "projects/projectID/databases/(default)/documents/C/d",
+                "fieldTransforms": [
+                  {
+                    "fieldPath": "b",
+                    "setToServerValue": "REQUEST_TIME"
+                  }
+                ]
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "a"
-            ]
-          },
-          "currentDocument": {
-            "exists": true
-          }
-        },
-        {
-          "transform": {
-            "document": "projects/projectID/databases/(default)/documents/C/d",
-            "fieldTransforms": [
-              {
-                "fieldPath": "b",
-                "setToServerValue": "REQUEST_TIME"
-              }
-            ]
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/testcase/update-uptime.json
+++ b/firestore/v1/testcase/update-uptime.json
@@ -1,0 +1,34 @@
+{
+  "description": "update: last-update-time precondition",
+  "comment": "The Update call supports a last-update-time precondition.",
+  "update": {
+    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+    "precondition": {
+      "updateTime": "1970-01-01T00:00:42Z"
+    },
+    "jsonData": "{\"a\": 1}",
+    "request": {
+      "database": "projects/projectID/databases/(default)",
+      "writes": [
+        {
+          "update": {
+            "name": "projects/projectID/databases/(default)/documents/C/d",
+            "fields": {
+              "a": {
+                "integerValue": "1"
+              }
+            }
+          },
+          "updateMask": {
+            "fieldPaths": [
+              "a"
+            ]
+          },
+          "currentDocument": {
+            "updateTime": "1970-01-01T00:00:42Z"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/firestore/v1/testcase/update-uptime.json
+++ b/firestore/v1/testcase/update-uptime.json
@@ -1,34 +1,38 @@
 {
-  "description": "update: last-update-time precondition",
-  "comment": "The Update call supports a last-update-time precondition.",
-  "update": {
-    "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
-    "precondition": {
-      "updateTime": "1970-01-01T00:00:42Z"
-    },
-    "jsonData": "{\"a\": 1}",
-    "request": {
-      "database": "projects/projectID/databases/(default)",
-      "writes": [
-        {
-          "update": {
-            "name": "projects/projectID/databases/(default)/documents/C/d",
-            "fields": {
-              "a": {
-                "integerValue": "1"
+  "tests": [
+    {
+      "description": "update: last-update-time precondition",
+      "comment": "The Update call supports a last-update-time precondition.",
+      "update": {
+        "docRefPath": "projects/projectID/databases/(default)/documents/C/d",
+        "precondition": {
+          "updateTime": "1970-01-01T00:00:42Z"
+        },
+        "jsonData": "{\"a\": 1}",
+        "request": {
+          "database": "projects/projectID/databases/(default)",
+          "writes": [
+            {
+              "update": {
+                "name": "projects/projectID/databases/(default)/documents/C/d",
+                "fields": {
+                  "a": {
+                    "integerValue": "1"
+                  }
+                }
+              },
+              "updateMask": {
+                "fieldPaths": [
+                  "a"
+                ]
+              },
+              "currentDocument": {
+                "updateTime": "1970-01-01T00:00:42Z"
               }
             }
-          },
-          "updateMask": {
-            "fieldPaths": [
-              "a"
-            ]
-          },
-          "currentDocument": {
-            "updateTime": "1970-01-01T00:00:42Z"
-          }
+          ]
         }
-      ]
+      }
     }
-  }
+  ]
 }

--- a/firestore/v1/validator.go
+++ b/firestore/v1/validator.go
@@ -46,7 +46,7 @@ func main() {
 			log.Fatal(err)
 		}
 
-		var test firestore_v1_tests.Test
+		var test firestore_v1_tests.TestSuite
 		if err := jsonpb.Unmarshal(bytes.NewBuffer(inBytes), &test); err != nil {
 			log.Fatal(err)
 		}

--- a/firestore/v1/validator.go
+++ b/firestore/v1/validator.go
@@ -1,0 +1,54 @@
+// Copyright 2019, Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+
+	firestore_v1_tests "./generated/google/cloud/conformance/firestore/v1"
+	"github.com/golang/protobuf/jsonpb"
+)
+
+func main() {
+	args := os.Args
+	dir := args[1]
+
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	for _, f := range files {
+		if !strings.Contains(f.Name(), ".json") {
+			continue
+		}
+
+		log.Printf("Validating: %v/%v", dir, f.Name())
+
+		inBytes, err := ioutil.ReadFile(dir + "/" + f.Name())
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		var test firestore_v1_tests.Test
+		if err := jsonpb.Unmarshal(bytes.NewBuffer(inBytes), &test); err != nil {
+			log.Fatal(err)
+		}
+	}
+}


### PR DESCRIPTION
* Update .kokoro/validator.sh to also validate firestore tests
* Add firestore/v1/validator.go to validate test cases conform to the
  schema defined in the proto definition.
* Update the proto package for firestore tests.proto to be
  `google.cloud.conformance.firestore.v1` from `tests`. With the
  planned addition of more projects having things in their own packages
  will help to prevent collisions. (Java package has been updated to
  follow, however other languages have not yet been updated.)