### PR TITLE
fix(firestore)!: update Firestore tests to use update_transform

### DIFF
--- a/firestore/v1/create-all-transforms.json
+++ b/firestore/v1/create-all-transforms.json
@@ -20,50 +20,45 @@
               },
               "currentDocument": {
                 "exists": false
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "setToServerValue": "REQUEST_TIME"
-                  },
-                  {
-                    "fieldPath": "c",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "fieldPath": "d",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "4"
-                        },
-                        {
-                          "integerValue": "5"
-                        },
-                        {
-                          "integerValue": "6"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "setToServerValue": "REQUEST_TIME"
+                },
+                {
+                  "fieldPath": "c",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                },
+                {
+                  "fieldPath": "d",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "4"
+                      },
+                      {
+                        "integerValue": "5"
+                      },
+                      {
+                        "integerValue": "6"
+                      }
+                    ]
+                  }
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/create-arrayremove-multi.json
+++ b/firestore/v1/create-arrayremove-multi.json
@@ -20,46 +20,41 @@
               },
               "currentDocument": {
                 "exists": false
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "fieldPath": "c.d",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "4"
-                        },
-                        {
-                          "integerValue": "5"
-                        },
-                        {
-                          "integerValue": "6"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                },
+                {
+                  "fieldPath": "c.d",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "4"
+                      },
+                      {
+                        "integerValue": "5"
+                      },
+                      {
+                        "integerValue": "6"
+                      }
+                    ]
+                  }
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/create-arrayremove-nested.json
+++ b/firestore/v1/create-arrayremove-nested.json
@@ -20,30 +20,25 @@
               },
               "currentDocument": {
                 "exists": false
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b.c",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b.c",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/create-arrayremove.json
+++ b/firestore/v1/create-arrayremove.json
@@ -20,30 +20,25 @@
               },
               "currentDocument": {
                 "exists": false
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/create-arrayunion-multi.json
+++ b/firestore/v1/create-arrayunion-multi.json
@@ -20,46 +20,41 @@
               },
               "currentDocument": {
                 "exists": false
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "fieldPath": "c.d",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "4"
-                        },
-                        {
-                          "integerValue": "5"
-                        },
-                        {
-                          "integerValue": "6"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                },
+                {
+                  "fieldPath": "c.d",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "4"
+                      },
+                      {
+                        "integerValue": "5"
+                      },
+                      {
+                        "integerValue": "6"
+                      }
+                    ]
+                  }
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/create-arrayunion-nested.json
+++ b/firestore/v1/create-arrayunion-nested.json
@@ -20,30 +20,25 @@
               },
               "currentDocument": {
                 "exists": false
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b.c",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b.c",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/create-arrayunion.json
+++ b/firestore/v1/create-arrayunion.json
@@ -20,30 +20,25 @@
               },
               "currentDocument": {
                 "exists": false
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/create-st-alone.json
+++ b/firestore/v1/create-st-alone.json
@@ -10,18 +10,19 @@
           "database": "projects/projectID/databases/(default)",
           "writes": [
             {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "a",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              },
               "currentDocument": {
                 "exists": false
-              }
+              },
+              "update": {
+                "fields": {},
+                "name": "projects/projectID/databases/(default)/documents/C/d"
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "a",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/create-st-multi.json
+++ b/firestore/v1/create-st-multi.json
@@ -20,22 +20,17 @@
               },
               "currentDocument": {
                 "exists": false
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "setToServerValue": "REQUEST_TIME"
-                  },
-                  {
-                    "fieldPath": "c.d",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "setToServerValue": "REQUEST_TIME"
+                },
+                {
+                  "fieldPath": "c.d",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/create-st-nested.json
+++ b/firestore/v1/create-st-nested.json
@@ -20,18 +20,13 @@
               },
               "currentDocument": {
                 "exists": false
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b.c",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b.c",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/create-st-with-empty-map.json
+++ b/firestore/v1/create-st-with-empty-map.json
@@ -28,18 +28,13 @@
               },
               "currentDocument": {
                 "exists": false
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "a.c",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "a.c",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/create-st.json
+++ b/firestore/v1/create-st.json
@@ -20,18 +20,13 @@
               },
               "currentDocument": {
                 "exists": false
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/set-all-transforms.json
+++ b/firestore/v1/set-all-transforms.json
@@ -17,50 +17,45 @@
                     "integerValue": "1"
                   }
                 }
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "setToServerValue": "REQUEST_TIME"
-                  },
-                  {
-                    "fieldPath": "c",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "fieldPath": "d",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "4"
-                        },
-                        {
-                          "integerValue": "5"
-                        },
-                        {
-                          "integerValue": "6"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "setToServerValue": "REQUEST_TIME"
+                },
+                {
+                  "fieldPath": "c",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                },
+                {
+                  "fieldPath": "d",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "4"
+                      },
+                      {
+                        "integerValue": "5"
+                      },
+                      {
+                        "integerValue": "6"
+                      }
+                    ]
+                  }
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/set-arrayremove-multi.json
+++ b/firestore/v1/set-arrayremove-multi.json
@@ -17,46 +17,41 @@
                     "integerValue": "1"
                   }
                 }
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "fieldPath": "c.d",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "4"
-                        },
-                        {
-                          "integerValue": "5"
-                        },
-                        {
-                          "integerValue": "6"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                },
+                {
+                  "fieldPath": "c.d",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "4"
+                      },
+                      {
+                        "integerValue": "5"
+                      },
+                      {
+                        "integerValue": "6"
+                      }
+                    ]
+                  }
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/set-arrayremove-nested.json
+++ b/firestore/v1/set-arrayremove-nested.json
@@ -17,30 +17,25 @@
                     "integerValue": "1"
                   }
                 }
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b.c",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b.c",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/set-arrayremove.json
+++ b/firestore/v1/set-arrayremove.json
@@ -17,30 +17,25 @@
                     "integerValue": "1"
                   }
                 }
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/set-arrayunion-multi.json
+++ b/firestore/v1/set-arrayunion-multi.json
@@ -17,46 +17,41 @@
                     "integerValue": "1"
                   }
                 }
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "fieldPath": "c.d",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "4"
-                        },
-                        {
-                          "integerValue": "5"
-                        },
-                        {
-                          "integerValue": "6"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                },
+                {
+                  "fieldPath": "c.d",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "4"
+                      },
+                      {
+                        "integerValue": "5"
+                      },
+                      {
+                        "integerValue": "6"
+                      }
+                    ]
+                  }
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/set-arrayunion-nested.json
+++ b/firestore/v1/set-arrayunion-nested.json
@@ -17,30 +17,25 @@
                     "integerValue": "1"
                   }
                 }
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b.c",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b.c",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/set-arrayunion.json
+++ b/firestore/v1/set-arrayunion.json
@@ -17,30 +17,25 @@
                     "integerValue": "1"
                   }
                 }
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/set-st-alone-mergeall.json
+++ b/firestore/v1/set-st-alone-mergeall.json
@@ -13,15 +13,19 @@
           "database": "projects/projectID/databases/(default)",
           "writes": [
             {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "a",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              "update": {
+                "fields": {},
+                "name": "projects/projectID/databases/(default)/documents/C/d"
+              },
+              "updateMask": {
+                "fieldPaths": []
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "a",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/set-st-alone.json
+++ b/firestore/v1/set-st-alone.json
@@ -13,18 +13,13 @@
               "update": {
                 "name": "projects/projectID/databases/(default)/documents/C/d",
                 "fields": {}
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "a",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "a",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/set-st-merge-both.json
+++ b/firestore/v1/set-st-merge-both.json
@@ -36,18 +36,13 @@
                 "fieldPaths": [
                   "a"
                 ]
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/set-st-merge-nonleaf-alone.json
+++ b/firestore/v1/set-st-merge-nonleaf-alone.json
@@ -26,18 +26,13 @@
                 "fieldPaths": [
                   "h"
                 ]
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "h.g",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "h.g",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/set-st-merge-nonleaf.json
+++ b/firestore/v1/set-st-merge-nonleaf.json
@@ -37,18 +37,13 @@
                 "fieldPaths": [
                   "h"
                 ]
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "h.g",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "h.g",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/set-st-merge-nowrite.json
+++ b/firestore/v1/set-st-merge-nowrite.json
@@ -19,15 +19,19 @@
           "database": "projects/projectID/databases/(default)",
           "writes": [
             {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              "update": {
+                "fields": {},
+                "name": "projects/projectID/databases/(default)/documents/C/d"
+              },
+              "updateMask": {
+                "fieldPaths": []
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/set-st-mergeall.json
+++ b/firestore/v1/set-st-mergeall.json
@@ -25,18 +25,13 @@
                 "fieldPaths": [
                   "a"
                 ]
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/set-st-multi.json
+++ b/firestore/v1/set-st-multi.json
@@ -17,22 +17,17 @@
                     "integerValue": "1"
                   }
                 }
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "setToServerValue": "REQUEST_TIME"
-                  },
-                  {
-                    "fieldPath": "c.d",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "setToServerValue": "REQUEST_TIME"
+                },
+                {
+                  "fieldPath": "c.d",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/set-st-nested.json
+++ b/firestore/v1/set-st-nested.json
@@ -17,18 +17,13 @@
                     "integerValue": "1"
                   }
                 }
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b.c",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b.c",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/set-st-with-empty-map.json
+++ b/firestore/v1/set-st-with-empty-map.json
@@ -25,18 +25,13 @@
                     }
                   }
                 }
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "a.c",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "a.c",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/set-st.json
+++ b/firestore/v1/set-st.json
@@ -17,18 +17,13 @@
                     "integerValue": "1"
                   }
                 }
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/update-all-transforms.json
+++ b/firestore/v1/update-all-transforms.json
@@ -25,50 +25,45 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "setToServerValue": "REQUEST_TIME"
-                  },
-                  {
-                    "fieldPath": "c",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "fieldPath": "d",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "4"
-                        },
-                        {
-                          "integerValue": "5"
-                        },
-                        {
-                          "integerValue": "6"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "setToServerValue": "REQUEST_TIME"
+                },
+                {
+                  "fieldPath": "c",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                },
+                {
+                  "fieldPath": "d",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "4"
+                      },
+                      {
+                        "integerValue": "5"
+                      },
+                      {
+                        "integerValue": "6"
+                      }
+                    ]
+                  }
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/update-arrayremove-alone.json
+++ b/firestore/v1/update-arrayremove-alone.json
@@ -10,31 +10,35 @@
           "database": "projects/projectID/databases/(default)",
           "writes": [
             {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "a",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
-                  }
-                ]
-              },
               "currentDocument": {
                 "exists": true
-              }
-            }
+              },
+              "update": {
+                "fields": {},
+                "name": "projects/projectID/databases/(default)/documents/C/d"
+              },
+              "updateMask": {
+                "fieldPaths": []
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "a",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
+                  }
+                }
+              ]
+            }  
           ]
         }
       }

--- a/firestore/v1/update-arrayremove-multi.json
+++ b/firestore/v1/update-arrayremove-multi.json
@@ -26,46 +26,41 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "fieldPath": "c.d",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "4"
-                        },
-                        {
-                          "integerValue": "5"
-                        },
-                        {
-                          "integerValue": "6"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                },
+                {
+                  "fieldPath": "c.d",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "4"
+                      },
+                      {
+                        "integerValue": "5"
+                      },
+                      {
+                        "integerValue": "6"
+                      }
+                    ]
+                  }
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/update-arrayremove-nested.json
+++ b/firestore/v1/update-arrayremove-nested.json
@@ -26,30 +26,25 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b.c",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b.c",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/update-arrayremove.json
+++ b/firestore/v1/update-arrayremove.json
@@ -25,30 +25,25 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/update-arrayunion-alone.json
+++ b/firestore/v1/update-arrayunion-alone.json
@@ -10,30 +10,34 @@
           "database": "projects/projectID/databases/(default)",
           "writes": [
             {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "a",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
-                  }
-                ]
-              },
               "currentDocument": {
                 "exists": true
-              }
+              },
+              "update": {
+                "fields": {},
+                "name": "projects/projectID/databases/(default)/documents/C/d"
+              },
+              "updateMask": {
+                "fieldPaths": []
+              },
+              "updateTransforms": [
+                {
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
+                  },
+                  "fieldPath": "a"
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/update-arrayunion-multi.json
+++ b/firestore/v1/update-arrayunion-multi.json
@@ -26,46 +26,41 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "fieldPath": "c.d",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "4"
-                        },
-                        {
-                          "integerValue": "5"
-                        },
-                        {
-                          "integerValue": "6"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                },
+                {
+                  "fieldPath": "c.d",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "4"
+                      },
+                      {
+                        "integerValue": "5"
+                      },
+                      {
+                        "integerValue": "6"
+                      }
+                    ]
+                  }
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/update-arrayunion-nested.json
+++ b/firestore/v1/update-arrayunion-nested.json
@@ -26,30 +26,25 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b.c",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b.c",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/update-arrayunion.json
+++ b/firestore/v1/update-arrayunion.json
@@ -25,30 +25,25 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/update-nested-transform-and-nested-value.json
+++ b/firestore/v1/update-nested-transform-and-nested-value.json
@@ -31,18 +31,13 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "a.c",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "a.c",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/update-paths-all-transforms.json
+++ b/firestore/v1/update-paths-all-transforms.json
@@ -52,50 +52,45 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "setToServerValue": "REQUEST_TIME"
-                  },
-                  {
-                    "fieldPath": "c",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "fieldPath": "d",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "4"
-                        },
-                        {
-                          "integerValue": "5"
-                        },
-                        {
-                          "integerValue": "6"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "setToServerValue": "REQUEST_TIME"
+                },
+                {
+                  "fieldPath": "c",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                },
+                {
+                  "fieldPath": "d",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "4"
+                      },
+                      {
+                        "integerValue": "5"
+                      },
+                      {
+                        "integerValue": "6"
+                      }
+                    ]
+                  }
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/update-paths-arrayremove-alone.json
+++ b/firestore/v1/update-paths-arrayremove-alone.json
@@ -19,30 +19,34 @@
           "database": "projects/projectID/databases/(default)",
           "writes": [
             {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "a",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
-                  }
-                ]
-              },
               "currentDocument": {
                 "exists": true
-              }
+              },
+              "update": {
+                "fields": {},
+                "name": "projects/projectID/databases/(default)/documents/C/d"
+              },
+              "updateMask": {
+                "fieldPaths": []
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "a",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
+                  }
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/update-paths-arrayremove-multi.json
+++ b/firestore/v1/update-paths-arrayremove-multi.json
@@ -47,46 +47,41 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "fieldPath": "c.d",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "4"
-                        },
-                        {
-                          "integerValue": "5"
-                        },
-                        {
-                          "integerValue": "6"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                },
+                {
+                  "fieldPath": "c.d",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "4"
+                      },
+                      {
+                        "integerValue": "5"
+                      },
+                      {
+                        "integerValue": "6"
+                      }
+                    ]
+                  }
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/update-paths-arrayremove-nested.json
+++ b/firestore/v1/update-paths-arrayremove-nested.json
@@ -41,30 +41,25 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b.c",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b.c",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/update-paths-arrayremove.json
+++ b/firestore/v1/update-paths-arrayremove.json
@@ -40,30 +40,25 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "removeAllFromArray": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "removeAllFromArray": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/update-paths-arrayunion-alone.json
+++ b/firestore/v1/update-paths-arrayunion-alone.json
@@ -19,30 +19,34 @@
           "database": "projects/projectID/databases/(default)",
           "writes": [
             {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "a",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
-                  }
-                ]
-              },
               "currentDocument": {
                 "exists": true
-              }
+              },
+              "update": {
+                "fields": {},
+                "name": "projects/projectID/databases/(default)/documents/C/d"
+              },
+              "updateMask": {
+                "fieldPaths": []
+              },
+              "updateTransforms": [
+                {
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
+                  },
+                  "fieldPath": "a"
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/update-paths-arrayunion-multi.json
+++ b/firestore/v1/update-paths-arrayunion-multi.json
@@ -47,46 +47,41 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
-                  },
-                  {
-                    "fieldPath": "c.d",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "4"
-                        },
-                        {
-                          "integerValue": "5"
-                        },
-                        {
-                          "integerValue": "6"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                },
+                {
+                  "fieldPath": "c.d",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "4"
+                      },
+                      {
+                        "integerValue": "5"
+                      },
+                      {
+                        "integerValue": "6"
+                      }
+                    ]
+                  }
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/update-paths-arrayunion-nested.json
+++ b/firestore/v1/update-paths-arrayunion-nested.json
@@ -41,30 +41,25 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b.c",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b.c",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/update-paths-arrayunion.json
+++ b/firestore/v1/update-paths-arrayunion.json
@@ -40,30 +40,25 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "appendMissingElements": {
-                      "values": [
-                        {
-                          "integerValue": "1"
-                        },
-                        {
-                          "integerValue": "2"
-                        },
-                        {
-                          "integerValue": "3"
-                        }
-                      ]
-                    }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "appendMissingElements": {
+                    "values": [
+                      {
+                        "integerValue": "1"
+                      },
+                      {
+                        "integerValue": "2"
+                      },
+                      {
+                        "integerValue": "3"
+                      }
+                    ]
                   }
-                ]
-              }
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/update-paths-nested-transform-and-nested-value.json
+++ b/firestore/v1/update-paths-nested-transform-and-nested-value.json
@@ -48,18 +48,13 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "a.c",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "a.c",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/update-paths-st-alone.json
+++ b/firestore/v1/update-paths-st-alone.json
@@ -19,18 +19,22 @@
           "database": "projects/projectID/databases/(default)",
           "writes": [
             {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "a",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              },
               "currentDocument": {
                 "exists": true
-              }
+              },
+              "update": {
+                "fields": {},
+                "name": "projects/projectID/databases/(default)/documents/C/d"
+              },
+              "updateMask": {
+                "fieldPaths": []
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "a",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/update-paths-st-multi.json
+++ b/firestore/v1/update-paths-st-multi.json
@@ -47,22 +47,17 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "setToServerValue": "REQUEST_TIME"
-                  },
-                  {
-                    "fieldPath": "c.d",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "setToServerValue": "REQUEST_TIME"
+                },
+                {
+                  "fieldPath": "c.d",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/update-paths-st-nested.json
+++ b/firestore/v1/update-paths-st-nested.json
@@ -41,18 +41,13 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b.c",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b.c",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/update-paths-st-with-empty-map.json
+++ b/firestore/v1/update-paths-st-with-empty-map.json
@@ -40,19 +40,14 @@
                   "a"
                 ]
               },
+              "updateTransforms": [
+                {
+                  "fieldPath": "a.c",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ],
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "a.c",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
               }
             }
           ]

--- a/firestore/v1/update-paths-st.json
+++ b/firestore/v1/update-paths-st.json
@@ -40,18 +40,13 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/update-st-alone.json
+++ b/firestore/v1/update-st-alone.json
@@ -10,18 +10,22 @@
           "database": "projects/projectID/databases/(default)",
           "writes": [
             {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "a",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              },
               "currentDocument": {
                 "exists": true
-              }
+              },
+              "update": {
+                "fields": {},
+                "name": "projects/projectID/databases/(default)/documents/C/d"
+              },
+              "updateMask": {
+                "fieldPaths": []
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "a",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/update-st-dot.json
+++ b/firestore/v1/update-st-dot.json
@@ -10,18 +10,22 @@
           "database": "projects/projectID/databases/(default)",
           "writes": [
             {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "a.b.c",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              },
               "currentDocument": {
                 "exists": true
-              }
+              },
+              "update": {
+                "fields": {},
+                "name": "projects/projectID/databases/(default)/documents/C/d"
+              },
+              "updateMask": {
+                "fieldPaths": []
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "a.b.c",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/update-st-multi.json
+++ b/firestore/v1/update-st-multi.json
@@ -26,22 +26,17 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "setToServerValue": "REQUEST_TIME"
-                  },
-                  {
-                    "fieldPath": "c.d",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "setToServerValue": "REQUEST_TIME"
+                },
+                {
+                  "fieldPath": "c.d",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/update-st-nested.json
+++ b/firestore/v1/update-st-nested.json
@@ -26,18 +26,13 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b.c",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b.c",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/update-st-with-empty-map.json
+++ b/firestore/v1/update-st-with-empty-map.json
@@ -33,18 +33,13 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "a.c",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "a.c",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }

--- a/firestore/v1/update-st.json
+++ b/firestore/v1/update-st.json
@@ -25,18 +25,13 @@
               },
               "currentDocument": {
                 "exists": true
-              }
-            },
-            {
-              "transform": {
-                "document": "projects/projectID/databases/(default)/documents/C/d",
-                "fieldTransforms": [
-                  {
-                    "fieldPath": "b",
-                    "setToServerValue": "REQUEST_TIME"
-                  }
-                ]
-              }
+              },
+              "updateTransforms": [
+                {
+                  "fieldPath": "b",
+                  "setToServerValue": "REQUEST_TIME"
+                }
+              ]
             }
           ]
         }


### PR DESCRIPTION
As part of implementing BulkWriter (go/firestore-bulk-writer-sdk), we are replacing usages of the `Write.transform` proto with `Write.update_transform`, which will result in changed conformance tests. These changes are already in the Node SDK.

Porting from [node](https://github.com/googleapis/nodejs-firestore/pull/1035).