### PR TITLE
fix: update firestore query-invalid-operator test to replace `!=` operator with `|~|`

### DIFF
--- a/firestore/v1/query-invalid-operator.json
+++ b/firestore/v1/query-invalid-operator.json
@@ -2,7 +2,7 @@
   "tests": [
     {
       "description": "query: invalid operator in Where clause",
-      "comment": "The !=  operator is not supported.",
+      "comment": "The |~| operator is not supported.",
       "query": {
         "collPath": "projects/projectID/databases/(default)/documents/C",
         "clauses": [
@@ -13,7 +13,7 @@
                   "a"
                 ]
               },
-              "op": "!=",
+              "op": "|~|",
               "jsonValue": "4"
             }
           }


### PR DESCRIPTION
Firestore now has support for != queries and this operator can no longer be used for this negative test case.