### PR TITLE
feat(storage): add scenario 6 test mixing retryable non-retryable errors

### DIFF
--- a/storage/v1/retry_tests.json
+++ b/storage/v1/retry_tests.json
@@ -190,6 +190,55 @@
       ],
       "preconditionProvided": false,
       "expectSuccess": false
+    },
+    {
+      "id": 6,
+      "description": "mix_retryable_non_retryable_errors",
+      "cases": [
+        {
+          "instructions": ["return-503", "return-400"]
+        },
+        {
+          "instructions": ["return-reset-connection", "return-401"]
+        }
+      ],
+      "methods": [
+        {"name": "storage.bucket_acl.get",                "resources": ["BUCKET"]},
+        {"name": "storage.bucket_acl.list",               "resources": ["BUCKET"]},
+        {"name": "storage.buckets.delete",                "resources": ["BUCKET"]},
+        {"name": "storage.buckets.get",                   "resources": ["BUCKET"]},
+        {"name": "storage.buckets.getIamPolicy",          "resources": ["BUCKET"]},
+        {"name": "storage.buckets.insert",                "resources": []},
+        {"name": "storage.buckets.list",                  "resources": ["BUCKET"]},
+        {"name": "storage.buckets.lockRetentionPolicy",   "resources": ["BUCKET"]},
+        {"name": "storage.buckets.patch",                 "resources": ["BUCKET"]},
+        {"name": "storage.buckets.setIamPolicy",          "resources": ["BUCKET"]},
+        {"name": "storage.buckets.testIamPermissions",    "resources": ["BUCKET"]},
+        {"name": "storage.buckets.update",                "resources": ["BUCKET"]},
+        {"name": "storage.default_object_acl.get",        "resources": ["BUCKET"]},
+        {"name": "storage.default_object_acl.list",       "resources": ["BUCKET"]},
+        {"name": "storage.hmacKey.delete",                "resources": ["HMAC_KEY"]},
+        {"name": "storage.hmacKey.get",                   "resources": ["HMAC_KEY"]},
+        {"name": "storage.hmacKey.list",                  "resources": ["HMAC_KEY"]},
+        {"name": "storage.hmacKey.update",                "resources": ["HMAC_KEY"]},
+        {"name": "storage.notifications.delete",          "resources": ["BUCKET", "NOTIFICATION"]},
+        {"name": "storage.notifications.get",             "resources": ["BUCKET", "NOTIFICATION"]},
+        {"name": "storage.notifications.list",            "resources": ["BUCKET", "NOTIFICATION"]},
+        {"name": "storage.object_acl.get",                "resources": ["BUCKET", "OBJECT"]},
+        {"name": "storage.object_acl.list",               "resources": ["BUCKET", "OBJECT"]},
+        {"name": "storage.objects.compose",               "resources": ["BUCKET", "OBJECT"]},
+        {"name": "storage.objects.copy",                  "resources": ["BUCKET", "OBJECT"]},
+        {"name": "storage.objects.delete",                "resources": ["BUCKET", "OBJECT"]},
+        {"name": "storage.objects.get",                   "resources": ["BUCKET", "OBJECT"]},
+        {"name": "storage.objects.list",                  "resources": ["BUCKET", "OBJECT"]},
+        {"name": "storage.objects.insert",                "resources": ["BUCKET"]},
+        {"name": "storage.objects.patch",                 "resources": ["BUCKET", "OBJECT"]},
+        {"name": "storage.objects.rewrite",               "resources": ["BUCKET", "OBJECT"]},
+        {"name": "storage.objects.update",                "resources": ["BUCKET", "OBJECT"]},
+        {"name": "storage.serviceaccount.get",            "resources": []}
+      ],
+      "preconditionProvided": true,
+      "expectSuccess": false
     }
   ]
 }


### PR DESCRIPTION
This adds to the retry conformance test schema scenario 6: Libraries behave correctly with a mix of retryable and non-retryable errors.

If a retryable error is followed on retry by a non-retryable error, the operation should fail, and all instruction cases should be fully consumed:
- "cases" (retryable error followed by a non-retryable error)
--  ["return-503", "return-400"]
-- ["return-reset-connection", "return-401"]
- "methods" 
--  include all methods from scenarios 1, 2&3
- "preconditionProvided": true,
- "expectSuccess": false

