### PR TITLE
chore: update trampoline image to go115

### DIFF
--- a/.kokoro/common.cfg
+++ b/.kokoro/common.cfg
@@ -9,7 +9,7 @@ build_file: "conformance-tests/.kokoro/trampoline.sh"
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/go112"
+    value: "gcr.io/cloud-devrel-kokoro-resources/go115"
 }
 
 # Tell the trampoline which build file to use.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/googleapis/conformance-tests
 
-go 1.16
+go 1.15
 
 require (
 	github.com/golang/protobuf v1.5.2


### PR DESCRIPTION
Updating trampoline image to use go115
- Go client libraries are currently compatible with Go 1.15, 1.16 and 1.17
- Dependency module gRPC requires at least Go 1.14
- Related -  internal cl/436523203 to update allowed_env_vars

```
# google.golang.org/grpc/status
/go/pkg/mod/google.golang.org/grpc@v1.45.0/status/status.go:128:5: undefined: errors.Is
/go/pkg/mod/google.golang.org/grpc@v1.45.0/status/status.go:131:5: undefined: errors.Is
note: module requires Go 1.14
```