### PR TITLE
chore: Add TestFile.retry_tests

### DIFF
--- a/storage/v1/proto/google/cloud/conformance/storage/v1/tests.proto
+++ b/storage/v1/proto/google/cloud/conformance/storage/v1/tests.proto
@@ -26,6 +26,10 @@ option go_package = "google/cloud/conformance/storage/v1";
 message TestFile {
   repeated SigningV4Test signing_v4_tests = 1;
   repeated PostPolicyV4Test post_policy_v4_tests = 2;
+  // Note: type is RetryTest rather than RetryTests.
+  // The data file can be loaded as either a TestFile or
+  // a RetryTests.
+  repeated RetryTest retry_tests = 3;
 }
 
 enum UrlStyle {


### PR DESCRIPTION
This allows languages which merge all test data files into a single TestFile to access the retry tests. Any language which explicitly loads retry_tests.json as a RetryTests message can continue to do so.