### PR TITLE
chore: Adds a test case for same qualifier across the families.

### DIFF
--- a/bigtable/v2/readrows.json
+++ b/bigtable/v2/readrows.json
@@ -1660,6 +1660,40 @@
           "qualifier": "C"
         }
       ]
+    },
+    {
+      "description": "same qualifier in multiple families",
+      "chunks": [
+        {
+          "rowKey": "Uks=",
+          "familyName": "A",
+          "qualifier": "Qw==",
+          "timestampMicros": "100",
+          "value": "dmFsdWUtVkFM",
+          "commitRow": false
+        },
+        {
+          "familyName": "B",
+          "qualifier": "Qw==",
+          "value": "dmFsdWUtVkFMXzE=",
+          "commitRow": true
+        }
+      ],
+      "results": [
+        {
+          "rowKey": "RK",
+          "familyName": "A",
+          "qualifier": "C",
+          "timestampMicros": "100",
+          "value": "value-VAL"
+        },
+        {
+          "rowKey": "RK",
+          "familyName": "B",
+          "qualifier": "C",
+          "value": "value-VAL_1"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Adds a new test case for the scenario identified by https://github.com/googleapis/google-cloud-dotnet/issues/9870

This newly added test case should fail currently. Test should start passing after the issue is fixed via https://github.com/googleapis/google-cloud-dotnet/pull/9921.

Currently, if there are 2 column families and both have the same qualifier, then the second family is not returned.
