### PR TITLE
chore: update go version to 1.21

### DIFF
--- a/.kokoro/common.cfg
+++ b/.kokoro/common.cfg
@@ -9,7 +9,7 @@ build_file: "conformance-tests/.kokoro/trampoline.sh"
 # Configure the docker image for kokoro-trampoline.
 env_vars: {
     key: "TRAMPOLINE_IMAGE"
-    value: "gcr.io/cloud-devrel-kokoro-resources/go117"
+    value: "gcr.io/cloud-devrel-kokoro-resources/go121"
 }
 
 # Tell the trampoline which build file to use.

--- a/.kokoro/validator.sh
+++ b/.kokoro/validator.sh
@@ -18,12 +18,6 @@ set -x
 
 cd github/conformance-tests
 
-# Update certs store due to expired certificate
-# https://ubuntu.com/security/notices/USN-5089-2
-apt-get install -y ca-certificates
-rm /usr/share/ca-certificates/mozilla/DST_Root_CA_X3.crt
-update-ca-certificates
-
 # Prerequisites:
 # 1. golang compiler must be installed and in PATH.
 # 2. protoc must be installed.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/googleapis/conformance-tests
 
-go 1.17
+go 1.21
 
 require (
 	github.com/golang/protobuf v1.5.3


### PR DESCRIPTION
Update go version to fix kokoro
- go client libraries are currently compatible with Go 1.19, 1.20 and 1.21
- google.golang.org/grpc requires Go 1.19+
- remove ca-certificates workaround as the package was updated
- corresponds to internal cl/600578622

fixes https://github.com/googleapis/conformance-tests/issues/83