### PR TITLE
chore: set gcs-sdk-team as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,4 +9,4 @@
 # Default owners for each product subdirectory.
 /bigtable/                            @googleapis/api-bigtable
 /firestore/                           @googleapis/api-firestore
-/storage/                             @googleapis/cloud-storage-dpe
+/storage/                             @googleapis/gcs-sdk-team


### PR DESCRIPTION
replace outdated cloud-storage-dpe group