### PR TITLE
chore: replace old partner teams with updated names

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,9 +4,9 @@
 # For syntax help see:
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#codeowners-syntax
 
-*     @googleapis/cloud-storage-dpe @googleapis/api-firestore @googleapis/api-bigtable 
+*     @googleapis/gcs-team @googleapis/firestore-team @googleapis/bigtable-team 
 
 # Default owners for each product subdirectory.
-/bigtable/                            @googleapis/api-bigtable
-/firestore/                           @googleapis/api-firestore
-/storage/                             @googleapis/cloud-storage-dpe
+/bigtable/                            @googleapis/bigtable-team
+/firestore/                           @googleapis/firestore-team
+/storage/                             @googleapis/gcs-team


### PR DESCRIPTION
This PR replaces old Bigtable, Firestore, and Storage teams with their updated names. b/478003109